### PR TITLE
Add ability to do in-line rule-based ignores

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,10 @@ _I stay woke - Erykah Badu_
     - [File globs](#file-globs)
     - [stdin](#stdin)
     - [Rules](#rules)
-    - [Ignoring files](#ignoring-files)
+    - [Ignoring](#ignoring)
+      - [Files](#files)
       - [`.wokeignore`](#wokeignore)
+      - [In-line ignoring](#in-line-ignoring)
     - [Exit Code](#exit-code)
   - [Tools](#tools)
   - [Resources](#resources)
@@ -170,7 +172,9 @@ rules:
       - allowlist
 ```
 
-### Ignoring files
+### Ignoring
+
+#### Files
 
 In your config file, you can ignore files by adding:
 
@@ -190,6 +194,36 @@ This follows the common `.gitignore` convention. See link for more details on ma
 
 You may also specify a `.wokeignore` file at the root of the directory to add additional ignore files.
 This also follows the `.gitignore` convention.
+
+#### In-line ignoring
+
+There may be times where you don't want to ignore an entire file.
+You may ignore a specific line for one or more rules by creating an in-line comment.
+
+This functionality is very rudimentary, it does a simple search for the phrase. Since
+`woke` is just a text file analyzer, it has no concept of the comment syntax for every file
+type it might encounter.
+
+Simply add the following to the line you wish to ignore, using comment syntax that is supported for your file type.
+(`woke` is not responsible for broken code due to in-line ignoring. Make sure you comment correctly!)
+
+```bash
+# wokeignore:rule=RULE_NAME
+
+# for example, to ignore the following line for the whitelist rule
+whitelist # wokeignore:rule=whitelist
+
+# or for multiple rules
+whitelist and blacklist # wokeignore:rule=whitelist,blacklist
+```
+
+Here's an example in go:
+
+```go
+func main() {
+  fmt.Println("here is the whitelist") // wokeignore:rule=whitelist
+}
+```
 
 ### Exit Code
 

--- a/pkg/result/result.go
+++ b/pkg/result/result.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/get-woke/woke/pkg/rule"
+	"github.com/rs/zerolog/log"
 )
 
 // Result contains data about the result of a broken rule
@@ -21,6 +22,16 @@ type Result struct {
 // filename and line are only used for the Position
 func FindResults(r *rule.Rule, filename, text string, line int) (rs []Result) {
 	text = strings.TrimSpace(text)
+
+	if r.CanIgnoreLine(text) {
+		log.Debug().
+			Str("rule", r.Name).
+			Str("file", filename).
+			Int("line", line).
+			Msg("ignoring via in-line")
+		return
+	}
+
 	idxs := r.FindAllStringIndex(text)
 
 	for _, idx := range idxs {

--- a/pkg/rule/rule_test.go
+++ b/pkg/rule/rule_test.go
@@ -49,3 +49,28 @@ func testRule() Rule {
 		Severity:     SevWarn,
 	}
 }
+
+func TestRule_CanIgnoreLine(t *testing.T) {
+	r := testRule()
+
+	tests := []struct {
+		name      string
+		line      string
+		assertion assert.BoolAssertionFunc
+	}{
+		{"violation without comment", "rule1", assert.False},
+		{"violation with correct comment", "rule1 #wokeignore:rule=rule1", assert.True},
+		{"violation with multiple rules", "rule1 #wokeignore:rule=rule1,rule2", assert.True},
+		{"violation with incorrect comment", "rule1 #wokeignore:rule=rule2", assert.False},
+		{"no violation with correct comment", "rule2 #wokeignore:rule=rule1", assert.True},
+		{"violation with text after ignore", "rule1 #wokeignore:rule=rule1 something else", assert.True},
+		{"violation with multiple ignores", "rule1 #wokeignore:rule=rule1 wokeignore:rule=rule2", assert.True},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.assertion(t, r.CanIgnoreLine(tt.line))
+		})
+	}
+
+}

--- a/test.txt
+++ b/test.txt
@@ -1,5 +1,0 @@
-These are words to avoid:
-* Blacklist
-* White-list
-* whitelist
-* blacklist


### PR DESCRIPTION
This adds the ability to add rule-specific in-line ignores, if you don't want to ignore the entire file.

I'm keeping it super basic intentionally. `woke` just searches for a string pattern, and if it finds it on the line, it ignores that line. Since this is a linter that can be used against any kinds of files, regardless of the language the files are written it, it has no concept of language-specific comment syntax (nor will it). Using a simple pattern matcher, `woke` can guarantee that it's in-line ignores can work on any kind of file that supports in-line comments.

Example:

```go
func main() {
  fmt.Println("here is the whitelist") // wokeignore:rule=whitelist
}
```