### PR TITLE
Remove usages of t.TempDir() to be compatible with golang 1.14.

### DIFF
--- a/pkg/ignore/ignore_test.go
+++ b/pkg/ignore/ignore_test.go
@@ -38,7 +38,7 @@ func TestIgnore_AddIgnoreFiles(t *testing.T) {
 }
 
 func TestAddRecursiveGitIgnores(t *testing.T) {
-	dir, err := ioutil.TempDir(t.TempDir(), "")
+	dir, err := ioutil.TempDir(os.TempDir(), "")
 	assert.NoError(t, err)
 	assert.DirExists(t, dir)
 	expected := make([]string, 0)

--- a/pkg/ignore/ignore_test.go
+++ b/pkg/ignore/ignore_test.go
@@ -40,6 +40,7 @@ func TestIgnore_AddIgnoreFiles(t *testing.T) {
 func TestAddRecursiveGitIgnores(t *testing.T) {
 	dir, err := ioutil.TempDir(os.TempDir(), "")
 	assert.NoError(t, err)
+	defer os.RemoveAll(dir)
 	assert.DirExists(t, dir)
 	expected := make([]string, 0)
 	lastDir := dir
@@ -58,7 +59,6 @@ func TestAddRecursiveGitIgnores(t *testing.T) {
 		expected = append(expected, filepath.Join(lastDir, content))
 		expected = append(expected, ignoreFilename)
 	}
-	defer os.RemoveAll(dir)
 	lines := addRecursiveGitIgnores([]string{".gitignore"}, []string{dir})
 	sort.Strings(lines)
 	sort.Strings(expected)
@@ -69,6 +69,7 @@ func TestAddRecursiveGitIgnores(t *testing.T) {
 func BenchmarkIgnoreAddIgnoreFiles(b *testing.B) {
 	dir, err := ioutil.TempDir(os.TempDir(), "")
 	assert.NoError(b, err)
+	defer os.RemoveAll(dir)
 	assert.DirExists(b, dir)
 	expected := []string{}
 
@@ -87,8 +88,6 @@ func BenchmarkIgnoreAddIgnoreFiles(b *testing.B) {
 		expected = append(expected, ignoreFilename)
 		expected = append(expected, filepath.Join(newDir, content))
 	}
-
-	defer os.RemoveAll(dir)
 	lines := addRecursiveGitIgnores([]string{".gitignore"}, []string{dir})
 	sort.Strings(lines)
 	sort.Strings(expected)

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -31,7 +31,6 @@ func parsePathTests(t *testing.T) {
 	t.Run("violation", func(t *testing.T) {
 		f1, err := newFile(t, "i have a whitelist\n")
 		assert.NoError(t, err)
-		defer os.Remove(f1.Name())
 		pr := new(testPrinter)
 		p := testParser()
 		violations := p.ParsePaths(pr, f1.Name())
@@ -78,6 +77,7 @@ func parsePathTests(t *testing.T) {
 	t.Run("IsTextFileFromFilename failure", func(t *testing.T) {
 		f, err := newFile(t, "")
 		assert.NoError(t, err)
+
 		p := testParser()
 		pr := new(testPrinter)
 		violations := p.ParsePaths(pr, f.Name())

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -172,7 +172,7 @@ func TestParser_ParsePaths(t *testing.T) {
 }
 
 func writeToStdin(t *testing.T, text string, f func()) error {
-	tmpfile, err := ioutil.TempFile(t.TempDir(), "")
+	tmpfile, err := ioutil.TempFile(os.TempDir(), "")
 	if err != nil {
 		return err
 	}

--- a/pkg/parser/violations_test.go
+++ b/pkg/parser/violations_test.go
@@ -13,8 +13,6 @@ import (
 
 func TestGenerateFileViolations(t *testing.T) {
 	f, err := newFile(t, "this has whitelist\n")
-	defer os.Remove(f.Name())
-
 	assert.NoError(t, err)
 
 	res, err := generateFileViolationsFromFilename(f.Name(), rule.DefaultRules)
@@ -55,6 +53,9 @@ func newFile(t *testing.T, text string) (*os.File, error) {
 	if err != nil {
 		return nil, err
 	}
+	t.Cleanup(func() {
+		os.Remove(tmpFile.Name())
+	})
 
 	b := []byte(text)
 	_, err = tmpFile.Write(b)

--- a/pkg/parser/violations_test.go
+++ b/pkg/parser/violations_test.go
@@ -51,7 +51,7 @@ func TestGenerateFileViolations(t *testing.T) {
 // newFile creates a new file for testing. The file, and the directory that the file
 // was created in will be removed at the completion of the test
 func newFile(t *testing.T, text string) (*os.File, error) {
-	tmpFile, err := ioutil.TempFile(t.TempDir(), "woke-")
+	tmpFile, err := ioutil.TempFile(os.TempDir(), "woke-")
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/walker/walker_test.go
+++ b/pkg/walker/walker_test.go
@@ -13,6 +13,7 @@ import (
 func TestWalker_Walk(t *testing.T) {
 	dir, err := ioutil.TempDir(os.TempDir(), "")
 	assert.NoError(t, err)
+	defer os.RemoveAll(dir)
 	assert.DirExists(t, dir)
 
 	for i := 0; i < 10; i++ {
@@ -30,7 +31,6 @@ func TestWalker_Walk(t *testing.T) {
 		assert.NoError(t, file.Close())
 	}
 
-	defer os.RemoveAll(dir)
 	err = Walk(dir, func(p string, typ os.FileMode) error {
 		assert.False(t, isDotGit(p), "path should not be returned in walk: %s", p)
 		return nil


### PR DESCRIPTION
As per title. `t.TempDir` and `os.TempDir` seemed used fairly inconsistently so I opted towards the more compatible `os.TempDir` solution.

If we want to go the other way round, we should probably explicitly state `1.15` as a requirement in `go.mod`.