### PR TITLE
Detect violations in filenames and paths as well

### DIFF
--- a/pkg/parser/testing.go
+++ b/pkg/parser/testing.go
@@ -1,0 +1,31 @@
+package parser
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+)
+
+// newFileWithPrefix creates a new file for testing with the given prefix. The file,
+// and the directory that the file was created in will be removed at the completion
+// of the test
+func newFileWithPrefix(t *testing.T, prefix, text string) (*os.File, error) {
+	tmpFile, err := ioutil.TempFile(os.TempDir(), prefix)
+	if err != nil {
+		return nil, err
+	}
+	t.Cleanup(func() {
+		os.Remove(tmpFile.Name())
+	})
+
+	b := []byte(text)
+	_, err = tmpFile.Write(b)
+
+	return tmpFile, err
+}
+
+// newFile creates a new file for testing. The file, and the directory that the file
+// was created in will be removed at the completion of the test
+func newFile(t *testing.T, text string) (*os.File, error) {
+	return newFileWithPrefix(t, "woke-", text)
+}

--- a/pkg/parser/violations.go
+++ b/pkg/parser/violations.go
@@ -48,6 +48,11 @@ func generateFileViolations(file *os.File, rules []*rule.Rule) (*result.FileResu
 		}
 
 		for _, r := range rules {
+			// Check the filename itself for violations
+			if line == 1 {
+				fileNameResults := result.FindResults(r, results.Filename, results.Filename, line)
+				results.Results = append(results.Results, fileNameResults...)
+			}
 			lineResults := result.FindResults(r, results.Filename, text, line)
 			results.Results = append(results.Results, lineResults...)
 		}

--- a/pkg/parser/violations_test.go
+++ b/pkg/parser/violations_test.go
@@ -24,6 +24,23 @@ func TestGenerateFileViolations(t *testing.T) {
 			{
 				Rule:      &rule.WhitelistRule,
 				Violation: "whitelist",
+				Line:      f.Name(),
+				StartPosition: &token.Position{
+					Filename: f.Name(),
+					Offset:   0,
+					Line:     1,
+					Column:   10,
+				},
+				EndPosition: &token.Position{
+					Filename: f.Name(),
+					Offset:   0,
+					Line:     1,
+					Column:   19,
+				},
+			},
+			{
+				Rule:      &rule.WhitelistRule,
+				Violation: "whitelist",
 				Line:      "this has whitelist",
 				StartPosition: &token.Position{
 					Filename: f.Name(),


### PR DESCRIPTION
Fixes #6 

This is a somewhat hacky implementation of a check for the filenames and paths of a repository. 

I won't be upset if you don't end up accepting this so please don't feel obliged to cater this in :slightly_smiling_face: 