### PR TITLE
Adding 'yinz' to list of alternatives for 'guys'

### DIFF
--- a/internal/rule/default.yaml
+++ b/internal/rule/default.yaml
@@ -76,6 +76,7 @@ rules:
       - people
       - you all
       - y'all
+      - yinz
 
   - name: whitebox
     terms:

--- a/pkg/rule/default.go
+++ b/pkg/rule/default.go
@@ -36,7 +36,7 @@ var GrandfatheredRule = Rule{
 var GuysRule = Rule{
 	Name:         "guys",
 	Terms:        []string{"guys"},
-	Alternatives: []string{"folks", "people", "you all", "y'all"},
+	Alternatives: []string{"folks", "people", "you all", "y'all", "yinz"},
 }
 
 // ManHoursRule is the default rule for "man-hours"


### PR DESCRIPTION
First of all, I love this project and want to contribute in a more impactful way in the future, for now I noticed that there's another second person plural alternative to `guys` that could be use, which is `yinz`!

https://en.wikipedia.org/wiki/Yinz

```Yinz (see History and usage below for other spellings) is a second-person plural pronoun used mainly in Western Pennsylvania English, most prominently in Pittsburgh, but it is also found throughout the cultural region known as Appalachia, located within the geographical region of the Appalachians.```

Its usage has risen slightly in popularity outside of the western PA area, similarly to `y'all,` partially due to its usefullness as a gender-neutral second personal plural! 
 