### PR TITLE
test: better ability to test the cmd package

### DIFF
--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -1,8 +1,10 @@
 package cmd
 
 import (
+	"regexp"
 	"testing"
 
+	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -14,6 +16,23 @@ import (
 //    go tool pprof cpu.prof
 func BenchmarkExecute(b *testing.B) {
 	for i := 0; i < b.N; i++ {
-		assert.NoError(b, TestExecute())
+		assert.NoError(b, rootRunE(new(cobra.Command), []string{".."}))
 	}
+}
+
+func TestRunE(t *testing.T) {
+	t.Cleanup(func() {
+		exitOneOnFailure = false
+		noIgnore = false
+	})
+	t.Run("no violations", func(t *testing.T) {
+		err := rootRunE(new(cobra.Command), []string{"../testdata"})
+		assert.NoError(t, err)
+	})
+	t.Run("violations w error", func(t *testing.T) {
+		exitOneOnFailure = true
+		err := rootRunE(new(cobra.Command), []string{"../testdata"})
+		assert.Error(t, err)
+		assert.Regexp(t, regexp.MustCompile(`^files with violations: \d`), err.Error())
+	})
 }


### PR DESCRIPTION
Testing the core functionality in the cmd package was difficult because of its interaction with cobra. This PR simply moves the logic that was within `rootCmd` into its own function to make testing easier