### PR TITLE
Add no violations feedback

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -115,9 +115,9 @@ func rootRunE(cmd *cobra.Command, args []string) error {
 		err = fmt.Errorf("files with violations: %d", violations)
 	}
 
-    if violations == 0 {
-        fmt.Println("No violations found. Stay woke \u270a")
-    }
+	if violations == 0 {
+		fmt.Println("No violations found. Stay woke \u270a")
+	}
 
 	return err
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -115,6 +115,10 @@ func rootRunE(cmd *cobra.Command, args []string) error {
 		err = fmt.Errorf("files with violations: %d", violations)
 	}
 
+    if violations == 0 {
+        fmt.Println("No violations found. Stay woke \u270a")
+    }
+
 	return err
 }
 

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -4,8 +4,8 @@ import (
 	"bytes"
 	"io"
 	"os"
-	"sync"
 	"regexp"
+	"sync"
 	"testing"
 
 	"github.com/spf13/cobra"
@@ -30,12 +30,12 @@ func TestRunE(t *testing.T) {
 		noIgnore = false
 	})
 	t.Run("no violations found", func(t *testing.T) {
-    	got := captureOutput(func() {
-           err := rootRunE(new(cobra.Command), []string{"../testdata/good.yml"})
-           assert.NoError(t, err)
-        })
-        expected := "No violations found. Stay woke \u270a\n"
-        assert.Equal(t, expected, got)
+		got := captureOutput(func() {
+			err := rootRunE(new(cobra.Command), []string{"../testdata/good.yml"})
+			assert.NoError(t, err)
+		})
+		expected := "No violations found. Stay woke \u270a\n"
+		assert.Equal(t, expected, got)
 	})
 	t.Run("violations w error", func(t *testing.T) {
 		exitOneOnFailure = true
@@ -44,6 +44,7 @@ func TestRunE(t *testing.T) {
 		assert.Regexp(t, regexp.MustCompile(`^files with violations: \d`), err.Error())
 	})
 }
+
 // Returns output of `os.Stdout` as string.
 // Based on https://medium.com/@hau12a1/golang-capturing-log-println-and-fmt-println-output-770209c791b4
 func captureOutput(f func()) string {

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -1,6 +1,10 @@
 package cmd
 
 import (
+	"bytes"
+	"io"
+	"os"
+	"sync"
 	"regexp"
 	"testing"
 
@@ -25,9 +29,13 @@ func TestRunE(t *testing.T) {
 		exitOneOnFailure = false
 		noIgnore = false
 	})
-	t.Run("no violations", func(t *testing.T) {
-		err := rootRunE(new(cobra.Command), []string{"../testdata"})
-		assert.NoError(t, err)
+	t.Run("no violations found", func(t *testing.T) {
+    	got := captureOutput(func() {
+           err := rootRunE(new(cobra.Command), []string{"../testdata/good.yml"})
+           assert.NoError(t, err)
+        })
+        expected := "No violations found. Stay woke \u270a\n"
+        assert.Equal(t, expected, got)
 	})
 	t.Run("violations w error", func(t *testing.T) {
 		exitOneOnFailure = true
@@ -35,4 +43,34 @@ func TestRunE(t *testing.T) {
 		assert.Error(t, err)
 		assert.Regexp(t, regexp.MustCompile(`^files with violations: \d`), err.Error())
 	})
+}
+// Returns output of `os.Stdout` as string.
+// Based on https://medium.com/@hau12a1/golang-capturing-log-println-and-fmt-println-output-770209c791b4
+func captureOutput(f func()) string {
+	reader, writer, err := os.Pipe()
+	if err != nil {
+		panic(err)
+	}
+	stdout := os.Stdout
+	stderr := os.Stderr
+	defer func() {
+		os.Stdout = stdout
+		os.Stderr = stderr
+	}()
+	os.Stdout = writer
+	os.Stderr = writer
+
+	out := make(chan string)
+	wg := new(sync.WaitGroup)
+	wg.Add(1)
+	go func() {
+		var buf bytes.Buffer
+		wg.Done()
+		_, _ = io.Copy(&buf, reader)
+		out <- buf.String()
+	}()
+	wg.Wait()
+	f()
+	writer.Close()
+	return <-out
 }

--- a/testdata/good.yml
+++ b/testdata/good.yml
@@ -1,0 +1,2 @@
+---
+this file has no violations.


### PR DESCRIPTION
When running woke, it is unclear to the users that the run was successful and that there were no violations found.

Adding some feedback to the user when no violations have been found and a test using a new yml file