### PR TITLE
Fix disabled rule causing false-positive filename violations

### DIFF
--- a/pkg/rule/rule.go
+++ b/pkg/rule/rule.go
@@ -74,6 +74,9 @@ func (r *Rule) MatchString2(s string, wordBoundary bool) bool {
 // MatchString reports whether the string s
 // contains any match of the regular expression re.
 func (r *Rule) MatchString(s string, wordBoundary bool) bool {
+	if len(r.Terms) == 0 {
+		return false
+	}
 	if wordBoundary {
 		if r.reWordBoundary == nil {
 			r.SetRegexp()

--- a/pkg/rule/rule_test.go
+++ b/pkg/rule/rule_test.go
@@ -102,3 +102,25 @@ func TestRule_MatchString(t *testing.T) {
 		})
 	}
 }
+
+func TestRule_EmptyTerms(t *testing.T) {
+	r := Rule{
+		Name:         "rule1",
+		Terms:        []string{},
+		Alternatives: []string{},
+		Severity:     SevWarn,
+	}
+	tests := []struct {
+		s         string
+		wb        bool
+		assertion assert.BoolAssertionFunc
+	}{
+		{s: "this has rule with empty terms", wb: false, assertion: assert.False},
+	}
+	for _, tt := range tests {
+		t.Run(tt.s, func(t *testing.T) {
+			fmt.Println(r.MatchString(tt.s, tt.wb), tt.s)
+			tt.assertion(t, r.MatchString(tt.s, tt.wb))
+		})
+	}
+}


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The commit message follows our [guidelines](https://github.com/get-woke/woke/blob/main/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix

**What is the current behavior?** (You can also link to an open issue here)

If I use emtpy terms in `.woke.yaml`, filename validations are always matched.

```yaml
rules:
  - name: dummy
```

https://github.com/get-woke/woke/pull/20#issuecomment-708845772

**What is the new behavior (if this is a feature change)?**

Ignore filenames with empty terms.

**Does this PR introduce a breaking change?** (What changes might users need to make due to this PR?)

No.

**Other information**:

No.