### PR TITLE
Use slashed paths for better output on Windows

### DIFF
--- a/pkg/parser/violations.go
+++ b/pkg/parser/violations.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"io"
 	"os"
+	"path/filepath"
 	"time"
 
 	"github.com/get-woke/woke/pkg/result"
@@ -24,16 +25,17 @@ func generateFileViolationsFromFilename(filename string, rules []*rule.Rule) (*r
 // generateFileViolations reads the file and returns results of places where rules are broken
 // this function will not close the file, that should be handled by the caller
 func generateFileViolations(file *os.File, rules []*rule.Rule) (*result.FileResults, error) {
+	filename := filepath.ToSlash(file.Name())
 	start := time.Now()
 	defer func() {
 		log.Debug().
 			TimeDiff("durationMS", time.Now(), start).
-			Str("file", file.Name()).
+			Str("file", filename).
 			Msg("finished generateFileViolations")
 	}()
 
 	results := &result.FileResults{
-		Filename: file.Name(),
+		Filename: filename,
 	}
 
 	// Check for violations in the filename itself

--- a/pkg/result/pathresult.go
+++ b/pkg/result/pathresult.go
@@ -30,10 +30,12 @@ func MatchPathRules(rules []*rule.Rule, path string) (rs []PathResult) {
 // MatchPath matches the path against the rule. If it is a match, it will
 // return a PathResult with the line/start column/end column all at 1
 func MatchPath(r *rule.Rule, path string) (rs []PathResult) {
+	path = filepath.ToSlash(path)
 	dir, filename := filepath.Split(path)
 	dirParts := append(filepath.SplitList(dir), strings.TrimSuffix(filename, filepath.Ext(filename)))
 
 	for _, p := range dirParts {
+		p = filepath.ToSlash(p)
 		if r.MatchString(p, false) {
 			rs = append(rs, PathResult{LineResult: NewLineResult(r, p, path, 1, 1, 1)})
 		}


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [ ] The commit message follows our [guidelines](https://github.com/get-woke/woke/blob/main/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix

**What is the current behavior?** (You can also link to an open issue here)

This is not a fixing for serious bug. The grep format output from the woke command should be better to be slash-separated paths.

**What is the new behavior (if this is a feature change)?**

Make slashed-paths on Windows.

**Does this PR introduce a breaking change?** (What changes might users need to make due to this PR?)

No.

**Other information**:

No.