### PR TITLE
Parse all text files, not just `text/plain`

### DIFF
--- a/pkg/util/contenttype.go
+++ b/pkg/util/contenttype.go
@@ -28,10 +28,10 @@ func detectContentType(file io.Reader) string {
 func isTextFile(file *os.File) bool {
 	contentType := detectContentType(file)
 
-	return strings.HasPrefix(contentType, "text/plain")
+	return strings.HasPrefix(contentType, "text/")
 }
 
-// IsTextFileFromFilename returns an error if the filename is not of content-type 'text/plain'
+// IsTextFileFromFilename returns an error if the filename is not of content-type 'text/*'
 func IsTextFileFromFilename(filename string) error {
 	f, err := os.Open(filename)
 	if err != nil {
@@ -41,7 +41,7 @@ func IsTextFileFromFilename(filename string) error {
 	return IsTextFile(f)
 }
 
-// IsTextFile returns an error if the file is not of content-type 'text/plain'
+// IsTextFile returns an error if the file is not of content-type 'text/*'
 func IsTextFile(file *os.File) error {
 	e, err := file.Stat()
 	if err != nil {

--- a/pkg/util/contenttype_test.go
+++ b/pkg/util/contenttype_test.go
@@ -8,45 +8,89 @@ import (
 )
 
 func TestIsTextFile(t *testing.T) {
-	f1, _ := os.Open("testdata/empty.txt")
-	defer f1.Close()
-	err := IsTextFile(f1)
-	assert.EqualError(t, err, ErrFileEmpty.Error())
+	t.Run("empty file", func(t *testing.T) {
+		f, _ := os.Open("testdata/empty.txt")
+		defer f.Close()
+		err := IsTextFile(f)
+		assert.EqualError(t, err, ErrFileEmpty.Error())
+	})
 
-	f2, _ := os.Open("testdata/binary.dat")
-	defer f2.Close()
-	err2 := IsTextFile(f2)
-	assert.EqualError(t, err2, ErrFileNotText.Error())
+	t.Run("html file", func(t *testing.T) {
+		f, _ := os.Open("testdata/index.html")
+		defer f.Close()
+		err := IsTextFile(f)
+		assert.NoError(t, err)
+	})
 
-	f3, _ := os.Open("testdata/text.txt")
-	defer f3.Close()
-	err3 := IsTextFile(f3)
-	assert.NoError(t, err3)
+	t.Run("binary file", func(t *testing.T) {
+		f, _ := os.Open("testdata/binary.dat")
+		defer f.Close()
+		err := IsTextFile(f)
+		assert.EqualError(t, err, ErrFileNotText.Error())
+	})
 
-	f4, _ := os.Open("testdata/missing.txt")
-	defer f4.Close()
-	err4 := IsTextFile(f4)
-	assert.Error(t, err4)
+	t.Run("text file", func(t *testing.T) {
+		f, _ := os.Open("testdata/text.txt")
+		defer f.Close()
+		err := IsTextFile(f)
+		assert.NoError(t, err)
+	})
 
-	f5, _ := os.Open("testdata")
-	defer f5.Close()
-	err5 := IsTextFile(f5)
-	assert.EqualError(t, err5, ErrIsDir.Error())
+	t.Run("xml file", func(t *testing.T) {
+		f, _ := os.Open("testdata/index.xml")
+		defer f.Close()
+		err := IsTextFile(f)
+		assert.NoError(t, err)
+	})
+
+	t.Run("missing file", func(t *testing.T) {
+		f, _ := os.Open("testdata/missing.txt")
+		defer f.Close()
+		err := IsTextFile(f)
+		assert.Error(t, err)
+	})
+
+	t.Run("directory", func(t *testing.T) {
+		f, _ := os.Open("testdata")
+		defer f.Close()
+		err := IsTextFile(f)
+		assert.EqualError(t, err, ErrIsDir.Error())
+	})
 }
 
 func TestIsTextFileFromFilename(t *testing.T) {
-	err := IsTextFileFromFilename("testdata/empty.txt")
-	assert.EqualError(t, err, ErrFileEmpty.Error())
+	t.Run("empty file", func(t *testing.T) {
+		err := IsTextFileFromFilename("testdata/empty.txt")
+		assert.EqualError(t, err, ErrFileEmpty.Error())
+	})
 
-	err2 := IsTextFileFromFilename("testdata/binary.dat")
-	assert.EqualError(t, err2, ErrFileNotText.Error())
+	t.Run("html file", func(t *testing.T) {
+		err := IsTextFileFromFilename("testdata/index.html")
+		assert.NoError(t, err)
+	})
 
-	err3 := IsTextFileFromFilename("testdata/text.txt")
-	assert.NoError(t, err3)
+	t.Run("binary file", func(t *testing.T) {
+		err := IsTextFileFromFilename("testdata/binary.dat")
+		assert.EqualError(t, err, ErrFileNotText.Error())
+	})
 
-	err4 := IsTextFileFromFilename("testdata/missing.txt")
-	assert.True(t, os.IsNotExist(err4))
+	t.Run("text file", func(t *testing.T) {
+		err := IsTextFileFromFilename("testdata/text.txt")
+		assert.NoError(t, err)
+	})
 
-	err5 := IsTextFileFromFilename("testdata")
-	assert.EqualError(t, err5, ErrIsDir.Error())
+	t.Run("xml file", func(t *testing.T) {
+		err := IsTextFileFromFilename("testdata/index.xml")
+		assert.NoError(t, err)
+	})
+
+	t.Run("missing file", func(t *testing.T) {
+		err := IsTextFileFromFilename("testdata/missing.txt")
+		assert.True(t, os.IsNotExist(err))
+	})
+
+	t.Run("directory", func(t *testing.T) {
+		err := IsTextFileFromFilename("testdata")
+		assert.EqualError(t, err, ErrIsDir.Error())
+	})
 }

--- a/pkg/util/testdata/index.html
+++ b/pkg/util/testdata/index.html
@@ -1,0 +1,9 @@
+<p align="center">
+  <a href="https://github.com/get-woke/woke">
+    <img alt="woke logo" src="https://raw.githubusercontent.com/get-woke/woke/main/assets/default-monochrome.svg" height="80" />
+  </a>
+  <h3 align="center">
+    Detect non-inclusive language in your source code.
+  </h3>
+  <p align="center"><i>I stay woke - Erykah Badu</i></p>
+</p>

--- a/pkg/util/testdata/index.xml
+++ b/pkg/util/testdata/index.xml
@@ -1,0 +1,6 @@
+<note>
+<to>John</to>
+<from>Jane</from>
+<heading>Reminder</heading>
+<body>Don't forget to get woke!</body>
+</note>


### PR DESCRIPTION
`http.DetectContentType` appears to categorize text files as `text/xml`, `text/plain` or `text/html`. We should parse them all

**Please check if the PR fulfills these requirements**

- [x] The commit message follows our [guidelines](https://github.com/get-woke/woke/blob/main/CONTRIBUTING.md)
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix


**What is the current behavior?** (You can also link to an open issue here)
Woke only parses `text/plain` file types


**What is the new behavior (if this is a feature change)?**
It will parse `text/xml`, `text/plain` or `text/html`.


**Does this PR introduce a breaking change?** (What changes might users need to make due to this PR?)
Somewhat. Woke will potentially parse _more_ files than before. This might warrant a v0.2 release

**Other information**:
