### PR TITLE
Add JSON output type

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ Flags:
       --exit-1-on-failure   Exit with exit code 1 on failures
   -h, --help                help for woke
       --no-ignore           Files matching entries in .gitignore/.wokeignore are parsed
-  -o, --output string       Output type [text,simple,github-actions] (default "text")
+  -o, --output string       Output type [text,simple,github-actions,json] (default "text")
       --stdin               Read from stdin
   -v, --version             version for woke
 ```

--- a/pkg/printer/json.go
+++ b/pkg/printer/json.go
@@ -1,0 +1,29 @@
+package printer
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/get-woke/woke/pkg/result"
+)
+
+// JSON is a JSON printer meant for a machine to read
+type JSON struct{}
+
+// NewJSON returns a new JSON printer
+func NewJSON() *JSON {
+	return &JSON{}
+}
+
+// Print prints in FileResults as json
+// NOTE: The JSON printer will bring each line result as a JSON string.
+// It will not be presented as an array of FileResults. You will neeed to
+// Split by new line to parse the full output
+func (p *JSON) Print(fs *result.FileResults) error {
+	b, err := json.Marshal(fs)
+	if err != nil {
+		return err
+	}
+	fmt.Println(string(b))
+	return nil
+}

--- a/pkg/printer/json.go
+++ b/pkg/printer/json.go
@@ -1,6 +1,7 @@
 package printer
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 
@@ -20,10 +21,8 @@ func NewJSON() *JSON {
 // It will not be presented as an array of FileResults. You will neeed to
 // Split by new line to parse the full output
 func (p *JSON) Print(fs *result.FileResults) error {
-	b, err := json.Marshal(fs)
-	if err != nil {
-		return err
-	}
-	fmt.Println(string(b))
-	return nil
+	var buf bytes.Buffer
+	err := json.NewEncoder(&buf).Encode(fs)
+	fmt.Print(buf.String()) // json Encoder already puts a new line in, so no need for Println here
+	return err
 }

--- a/pkg/printer/json_test.go
+++ b/pkg/printer/json_test.go
@@ -12,6 +12,6 @@ func TestJSON_Print(t *testing.T) {
 	got := captureOutput(func() {
 		assert.NoError(t, p.Print(res))
 	})
-	expected := `{"Filename":"foo.txt","Results":[{"Rule":{"Name":"blacklist","Terms":["blacklist","black-list","blacklisted","black-listed"],"Alternatives":["denylist","blocklist"],"Note":"","Severity":"warning"},"Violation":"blacklist","Line":"this blacklist must change","StartPosition":{"Filename":"foo.txt","Offset":0,"Line":1,"Column":6},"EndPosition":{"Filename":"foo.txt","Offset":0,"Line":1,"Column":15}}]}` + "\n"
+	expected := `{"Filename":"foo.txt","Results":[{"Rule":{"Name":"blacklist","Terms":["blacklist","black-list","blacklisted","black-listed"],"Alternatives":["denylist","blocklist"],"Note":"","Severity":"warning"},"Violation":"blacklist","Line":"this blacklist must change","StartPosition":{"Filename":"foo.txt","Offset":0,"Line":1,"Column":6},"EndPosition":{"Filename":"foo.txt","Offset":0,"Line":1,"Column":15},"Reason":"` + "`blacklist`" + ` may be insensitive, use ` + "`denylist`" + `, ` + "`blocklist`" + ` instead"}]}` + "\n"
 	assert.Equal(t, expected, got)
 }

--- a/pkg/printer/json_test.go
+++ b/pkg/printer/json_test.go
@@ -1,0 +1,17 @@
+package printer
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestJSON_Print(t *testing.T) {
+	p := NewJSON()
+	res := generateFileResult()
+	got := captureOutput(func() {
+		assert.NoError(t, p.Print(res))
+	})
+	expected := `{"Filename":"foo.txt","Results":[{"Rule":{"Name":"blacklist","Terms":["blacklist","black-list","blacklisted","black-listed"],"Alternatives":["denylist","blocklist"],"Note":"","Severity":"warning"},"Violation":"blacklist","Line":"this blacklist must change","StartPosition":{"Filename":"foo.txt","Offset":0,"Line":1,"Column":6},"EndPosition":{"Filename":"foo.txt","Offset":0,"Line":1,"Column":15}}]}` + "\n"
+	assert.Equal(t, expected, got)
+}

--- a/pkg/printer/printer.go
+++ b/pkg/printer/printer.go
@@ -23,6 +23,9 @@ const (
 	// OutFormatGitHubActions is an output format supported by GitHub Actions annotations
 	// https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-commands-for-github-actions#setting-a-warning-message
 	OutFormatGitHubActions = "github-actions"
+
+	// OutFormatJSON outputs in json
+	OutFormatJSON = "json"
 )
 
 // OutFormats are all the available output formats. The first one should be the default
@@ -30,6 +33,7 @@ var OutFormats = []string{
 	OutFormatText,
 	OutFormatSimple,
 	OutFormatGitHubActions,
+	OutFormatJSON,
 }
 
 // OutFormatsString is all OutFormats, as a comma-separated string
@@ -45,6 +49,8 @@ func NewPrinter(f string) (Printer, error) {
 		p = NewSimple()
 	case OutFormatGitHubActions:
 		p = NewGitHubActions()
+	case OutFormatJSON:
+		p = NewJSON()
 	default:
 		return p, fmt.Errorf("%s is not a valid printer type", f)
 	}

--- a/pkg/printer/printer_test.go
+++ b/pkg/printer/printer_test.go
@@ -14,6 +14,7 @@ func TestCreatePrinter(t *testing.T) {
 		{OutFormatSimple, &Simple{}},
 		{OutFormatText, &Text{}},
 		{OutFormatGitHubActions, &GitHubActions{}},
+		{OutFormatJSON, &JSON{}},
 	}
 
 	for _, test := range tests {

--- a/pkg/result/lineresult.go
+++ b/pkg/result/lineresult.go
@@ -1,6 +1,7 @@
 package result
 
 import (
+	"encoding/json"
 	"fmt"
 	"go/token"
 	"strings"
@@ -97,3 +98,16 @@ func (r LineResult) GetEndPosition() *token.Position { return r.EndPosition }
 
 // GetLine returns the entire line for the LineResult
 func (r LineResult) GetLine() string { return r.Line }
+
+type jsonLineResult LineResult
+
+// MarshalJSON override to include Reason in the json response
+func (r LineResult) MarshalJSON() ([]byte, error) {
+	return json.Marshal(struct {
+		jsonLineResult
+		Reason string
+	}{
+		jsonLineResult: jsonLineResult(r),
+		Reason:         r.Reason(),
+	})
+}

--- a/pkg/result/lineresult_test.go
+++ b/pkg/result/lineresult_test.go
@@ -2,6 +2,7 @@ package result
 
 import (
 	"fmt"
+	"go/token"
 	"testing"
 
 	"github.com/get-woke/woke/pkg/rule"
@@ -20,4 +21,41 @@ func TestFindResults(t *testing.T) {
 
 	rs = FindResults(&rule.WhitelistRule, "my/file", "this has the term whitelist #wokeignore:rule=whitelist", 1)
 	assert.Len(t, rs, 0)
+}
+
+func TestLineResult_MarshalJSON(t *testing.T) {
+	lr := testLineResult()
+	b, err := lr.MarshalJSON()
+	assert.NoError(t, err)
+	assert.Contains(t, string(b), fmt.Sprintf(`"Reason":"%s"`, lr.Reason()))
+}
+
+func TestLineResult_GetSeverity(t *testing.T) {
+	lr := testLineResult()
+	assert.Equal(t, lr.GetSeverity(), lr.Rule.Severity)
+}
+
+func TestLineResult_GetStartPosition(t *testing.T) {
+	lr := testLineResult()
+	assert.Equal(t, lr.GetStartPosition(), lr.StartPosition)
+}
+
+func TestLineResult_GetEndPosition(t *testing.T) {
+	lr := testLineResult()
+	assert.Equal(t, lr.GetEndPosition(), lr.EndPosition)
+}
+
+func TestLineResult_GetLine(t *testing.T) {
+	lr := testLineResult()
+	assert.Equal(t, lr.GetLine(), lr.Line)
+}
+
+func testLineResult() LineResult {
+	return LineResult{
+		Rule:          &rule.WhitelistRule,
+		Violation:     "whitelist",
+		Line:          "whitelist",
+		StartPosition: &token.Position{Line: 1, Offset: 0},
+		EndPosition:   &token.Position{Line: 1, Offset: 8},
+	}
 }

--- a/pkg/rule/severity.go
+++ b/pkg/rule/severity.go
@@ -1,6 +1,8 @@
 package rule
 
 import (
+	"encoding/json"
+
 	"github.com/fatih/color"
 	"gopkg.in/yaml.v2"
 )
@@ -66,4 +68,12 @@ func (s *Severity) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	*s = NewSeverity(str)
 
 	return nil
+}
+
+// compile-time check that Severity satisfies the yaml Unmarshaler
+var _ json.Marshaler = (*Severity)(nil)
+
+// MarshalJSON to marshal Severity as a string
+func (s *Severity) MarshalJSON() ([]byte, error) {
+	return []byte(`"` + s.String() + `"`), nil
 }

--- a/pkg/rule/severity_test.go
+++ b/pkg/rule/severity_test.go
@@ -18,6 +18,12 @@ func TestSeverity_UnmarshalYAML(t *testing.T) {
 		{"error", SevError},
 		{"info", SevInfo},
 		{"not-valid", SevInfo},
+		{"0", SevInfo},
+		{"1", SevInfo},
+		{"2", SevInfo},
+		{"3", SevInfo},
+		{"4", SevInfo},
+		{"99", SevInfo},
 	}
 	for _, test := range tests {
 		sev := new(Severity)
@@ -25,6 +31,24 @@ func TestSeverity_UnmarshalYAML(t *testing.T) {
 		assert.NoError(t, err)
 
 		assert.Equalf(t, test.expected, *sev, "expected: %s, got: %s", test.expected, sev)
+	}
+}
+
+func TestSeverity_MarshalJSON(t *testing.T) {
+	tests := []struct {
+		input    Severity
+		expected string
+	}{
+		{SevWarn, `"warning"`},
+		{SevError, `"error"`},
+		{SevInfo, `"info"`},
+	}
+	for _, test := range tests {
+		sev := new(Severity)
+		b, err := test.input.MarshalJSON()
+		assert.NoError(t, err)
+
+		assert.Equalf(t, test.expected, string(b), "expected: %s, got: %s", test.expected, sev)
 	}
 }
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The commit message follows our [guidelines](https://github.com/get-woke/woke/blob/main/CONTRIBUTING.md)
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Feature


**What is the current behavior?** (You can also link to an open issue here)
No JSON printer


**What is the new behavior (if this is a feature change)?**
Outputs file results as a json string. This will be very helpful for IDE integrations

_Note_ that this will not be an array of FileResults, but will be separate JSON strings for each file result, since the results are written to the console asynchronously. 


**Does this PR introduce a breaking change?** (What changes might users need to make due to this PR?)
No

**Other information**:
