### PR TITLE
Bug fix: Only trim trailing new-line when reading lines

### DIFF
--- a/pkg/parser/violations.go
+++ b/pkg/parser/violations.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/get-woke/woke/pkg/result"
@@ -54,6 +55,9 @@ func generateFileViolations(file *os.File, rules []*rule.Rule) (*result.FileResu
 		if err != nil {
 			return nil, err
 		}
+
+		// text will have a trailing new line, trim it
+		text = strings.TrimSuffix(text, "\n")
 
 		for _, r := range rules {
 			lineResults := result.FindResults(r, results.Filename, text, line)

--- a/pkg/parser/violations_test.go
+++ b/pkg/parser/violations_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func TestGenerateFileViolations(t *testing.T) {
-	f, err := newFile(t, "this has whitelist\n")
+	f, err := newFile(t, " this has whitelist\n")
 	assert.NoError(t, err)
 
 	res, err := generateFileViolationsFromFilename(f.Name(), rule.DefaultRules)
@@ -28,18 +28,18 @@ func TestGenerateFileViolations(t *testing.T) {
 	expected.Results[0] = result.LineResult{
 		Rule:      &rule.WhitelistRule,
 		Violation: "whitelist",
-		Line:      "this has whitelist",
+		Line:      " this has whitelist",
 		StartPosition: &token.Position{
 			Filename: filename,
 			Offset:   0,
 			Line:     1,
-			Column:   9,
+			Column:   10,
 		},
 		EndPosition: &token.Position{
 			Filename: filename,
 			Offset:   0,
 			Line:     1,
-			Column:   18,
+			Column:   19,
 		},
 	}
 	assert.EqualValues(t, expected, res)

--- a/pkg/result/lineresult.go
+++ b/pkg/result/lineresult.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"go/token"
-	"strings"
 
 	"github.com/get-woke/woke/pkg/rule"
 
@@ -48,8 +47,6 @@ func NewLineResult(r *rule.Rule, violation, filename string, line, startColumn, 
 // FindResults returns the results that match the rule for the given text.
 // filename and line are only used for the Position
 func FindResults(r *rule.Rule, filename, text string, line int) (rs []Result) {
-	text = strings.TrimSpace(text)
-
 	if r.CanIgnoreLine(text) {
 		log.Debug().
 			Str("rule", r.Name).


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The commit message follows our [guidelines](https://github.com/get-woke/woke/blob/main/CONTRIBUTING.md)
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix


**What is the current behavior?** (You can also link to an open issue here)
Currently, all leading/trailing whitespace will be trimmed from each line before it is parsed. This will cause the column value for violations to be incorrect if the line has leading whitespace.


**What is the new behavior (if this is a feature change)?**
Do not trim whitespace anymore, only trim the trailing new line.


**Does this PR introduce a breaking change?** (What changes might users need to make due to this PR?)
No

**Other information**:
