### PR TITLE
Bug fix: last line of a file that does not end in a new line is no longer skipped

### DIFF
--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -31,7 +31,7 @@ func testParser() *Parser {
 
 func parsePathTests(t *testing.T) {
 	t.Run("violation", func(t *testing.T) {
-		f, err := newFile(t, "i have a whitelist\n")
+		f, err := newFile(t, "i have a whitelist")
 		assert.NoError(t, err)
 		pr := new(testPrinter)
 		p := testParser()

--- a/pkg/parser/violations_test.go
+++ b/pkg/parser/violations_test.go
@@ -14,38 +14,55 @@ import (
 )
 
 func TestGenerateFileViolations(t *testing.T) {
-	f, err := newFile(t, " this has whitelist\n")
-	assert.NoError(t, err)
-
-	res, err := generateFileViolationsFromFilename(f.Name(), rule.DefaultRules)
-	assert.NoError(t, err)
-
-	filename := filepath.ToSlash(f.Name())
-	expected := &result.FileResults{
-		Filename: filename,
-		Results:  make([]result.Result, 1),
+	tests := []struct {
+		desc    string
+		content string
+		line    string
+		start   int
+		end     int
+	}{
+		{"leading whitespace", " this has whitelist\n", " this has whitelist", 10, 19},
+		{"no leading whitespace", "this has whitelist\n", "this has whitelist", 9, 18},
+		{"leading whitespace, no new line", " this has whitelist", " this has whitelist", 10, 19},
+		{"no leading whitespace, no new line", "this has whitelist", "this has whitelist", 9, 18},
 	}
-	expected.Results[0] = result.LineResult{
-		Rule:      &rule.WhitelistRule,
-		Violation: "whitelist",
-		Line:      " this has whitelist",
-		StartPosition: &token.Position{
-			Filename: filename,
-			Offset:   0,
-			Line:     1,
-			Column:   10,
-		},
-		EndPosition: &token.Position{
-			Filename: filename,
-			Offset:   0,
-			Line:     1,
-			Column:   19,
-		},
-	}
-	assert.EqualValues(t, expected, res)
+	for _, tc := range tests {
+		t.Run(tc.desc, func(t *testing.T) {
+			f, err := newFile(t, tc.content)
+			assert.NoError(t, err)
 
-	_, err = generateFileViolationsFromFilename("missing.file", rule.DefaultRules)
-	assert.Error(t, err)
+			res, err := generateFileViolationsFromFilename(f.Name(), rule.DefaultRules)
+			assert.NoError(t, err)
+
+			filename := filepath.ToSlash(f.Name())
+			expected := &result.FileResults{
+				Filename: filename,
+				Results:  make([]result.Result, 1),
+			}
+			expected.Results[0] = result.LineResult{
+				Rule:      &rule.WhitelistRule,
+				Violation: "whitelist",
+				Line:      tc.line,
+				StartPosition: &token.Position{
+					Filename: filename,
+					Offset:   0,
+					Line:     1,
+					Column:   tc.start,
+				},
+				EndPosition: &token.Position{
+					Filename: filename,
+					Offset:   0,
+					Line:     1,
+					Column:   tc.end,
+				},
+			}
+			assert.EqualValues(t, expected, res)
+		})
+	}
+	t.Run("missing file", func(t *testing.T) {
+		_, err := generateFileViolationsFromFilename("missing.file", rule.DefaultRules)
+		assert.Error(t, err)
+	})
 }
 
 // newFile creates a new file for testing. The file, and the directory that the file

--- a/pkg/parser/violations_test.go
+++ b/pkg/parser/violations_test.go
@@ -63,12 +63,28 @@ func TestGenerateFileViolations(t *testing.T) {
 		_, err := generateFileViolationsFromFilename("missing.file", rule.DefaultRules)
 		assert.Error(t, err)
 	})
+
+	t.Run("filename violation", func(t *testing.T) {
+		f, err := newFileWithPrefix(t, "whitelist-", "content")
+		assert.NoError(t, err)
+
+		res, err := generateFileViolationsFromFilename(f.Name(), rule.DefaultRules)
+		assert.NoError(t, err)
+		assert.Len(t, res.Results, 1)
+		assert.Regexp(t, "^Filename violation: ", res.Results[0].Reason())
+	})
 }
 
 // newFile creates a new file for testing. The file, and the directory that the file
 // was created in will be removed at the completion of the test
 func newFile(t *testing.T, text string) (*os.File, error) {
-	tmpFile, err := ioutil.TempFile(os.TempDir(), "woke-")
+	return newFileWithPrefix(t, "woke-", text)
+}
+
+// newFile creates a new file with the prefix defined for testing.
+// The file, and the directory that the file was created in will be removed at the completion of the test
+func newFileWithPrefix(t *testing.T, prefix, text string) (*os.File, error) {
+	tmpFile, err := ioutil.TempFile(os.TempDir(), prefix)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The commit message follows our [guidelines](https://github.com/get-woke/woke/blob/main/CONTRIBUTING.md)
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix


**What is the current behavior?** (You can also link to an open issue here)
Files without a final new line at the end of a file will not parse the final line.


**What is the new behavior (if this is a feature change)?**
Parse the last line of a file when it does not have a new line.
ReadString('\n') will return io.EOF + text for a line that has content but does not have a trailing new line. We will handle that case specifically
https://golang.org/pkg/bufio/#Reader.ReadString


**Does this PR introduce a breaking change?** (What changes might users need to make due to this PR?)
No

**Other information**:
