### PR TITLE
Add rule option for enabling/disabling word boundary

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ Companies like [GitHub](https://github.com/github/renaming), [Twitter](https://t
   - [File globs](#file-globs)
   - [stdin](#stdin)
   - [Rules](#rules)
+    - [Options](#options)
     - [Disabling Default Rules](#disabling-default-rules)
   - [Ignoring](#ignoring)
     - [Files](#files)
@@ -202,7 +203,19 @@ rules:
       - white-list
     alternatives:
       - allowlist
+    # options:
+    #   word_boundary: false
 ```
+
+#### Options
+
+You can configure options for each rule. Add an `options` key to your rule definition to customize.
+
+Current options include:
+
+- `word_boundary` (default: `false`)
+  - If `true`, terms will trigger violations when they are surrounded by ASCII word boundaries.
+  - If `false`, will trigger violations if the term if found anywhere in the line, regardless if it is within an ASCII word boundary.
 
 #### Disabling Default Rules
 

--- a/internal/rule/gen.go
+++ b/internal/rule/gen.go
@@ -89,6 +89,9 @@ var {{ .Name | sanitize }}Rule = Rule{
 	{{- if .Severity }}
 	Severity: {{ printf "%#v" .Severity }},
 	{{- end }}
+	Options: Options{
+		WordBoundary: {{ .Options.WordBoundary }},
+	},
 }
 {{- end }}
 

--- a/pkg/printer/json_test.go
+++ b/pkg/printer/json_test.go
@@ -12,6 +12,6 @@ func TestJSON_Print(t *testing.T) {
 	got := captureOutput(func() {
 		assert.NoError(t, p.Print(res))
 	})
-	expected := `{"Filename":"foo.txt","Results":[{"Rule":{"Name":"blacklist","Terms":["blacklist","black-list","blacklisted","black-listed"],"Alternatives":["denylist","blocklist"],"Note":"","Severity":"warning"},"Violation":"blacklist","Line":"this blacklist must change","StartPosition":{"Filename":"foo.txt","Offset":0,"Line":1,"Column":6},"EndPosition":{"Filename":"foo.txt","Offset":0,"Line":1,"Column":15},"Reason":"` + "`blacklist`" + ` may be insensitive, use ` + "`denylist`" + `, ` + "`blocklist`" + ` instead"}]}` + "\n"
+	expected := `{"Filename":"foo.txt","Results":[{"Rule":{"Name":"blacklist","Terms":["blacklist","black-list","blacklisted","black-listed"],"Alternatives":["denylist","blocklist"],"Note":"","Severity":"warning","Options":{"WordBoundary":false}},"Violation":"blacklist","Line":"this blacklist must change","StartPosition":{"Filename":"foo.txt","Offset":0,"Line":1,"Column":6},"EndPosition":{"Filename":"foo.txt","Offset":0,"Line":1,"Column":15},"Reason":"` + "`blacklist`" + ` may be insensitive, use ` + "`denylist`" + `, ` + "`blocklist`" + ` instead"}]}` + "\n"
 	assert.Equal(t, expected, got)
 }

--- a/pkg/rule/default.go
+++ b/pkg/rule/default.go
@@ -8,6 +8,9 @@ var BlackboxRule = Rule{
 	Name:         "blackbox",
 	Terms:        []string{"black-box", "blackbox", "black box"},
 	Alternatives: []string{"closed-box"},
+	Options: Options{
+		WordBoundary: false,
+	},
 }
 
 // BlacklistRule is the default rule for "blacklist"
@@ -16,6 +19,9 @@ var BlacklistRule = Rule{
 	Terms:        []string{"blacklist", "black-list", "blacklisted", "black-listed"},
 	Alternatives: []string{"denylist", "blocklist"},
 	Severity:     1,
+	Options: Options{
+		WordBoundary: false,
+	},
 }
 
 // DummyRule is the default rule for "dummy"
@@ -23,6 +29,9 @@ var DummyRule = Rule{
 	Name:         "dummy",
 	Terms:        []string{"dummy"},
 	Alternatives: []string{"placeholder", "sample"},
+	Options: Options{
+		WordBoundary: false,
+	},
 }
 
 // GrandfatheredRule is the default rule for "grandfathered"
@@ -30,6 +39,9 @@ var GrandfatheredRule = Rule{
 	Name:         "grandfathered",
 	Terms:        []string{"grandfathered"},
 	Alternatives: []string{"legacy status"},
+	Options: Options{
+		WordBoundary: false,
+	},
 }
 
 // GuysRule is the default rule for "guys"
@@ -37,6 +49,9 @@ var GuysRule = Rule{
 	Name:         "guys",
 	Terms:        []string{"guys"},
 	Alternatives: []string{"folks", "people", "you all", "y'all", "yinz"},
+	Options: Options{
+		WordBoundary: false,
+	},
 }
 
 // ManHoursRule is the default rule for "man-hours"
@@ -44,6 +59,9 @@ var ManHoursRule = Rule{
 	Name:         "man-hours",
 	Terms:        []string{"man hours", "man-hours"},
 	Alternatives: []string{"person hours", "engineer hours"},
+	Options: Options{
+		WordBoundary: false,
+	},
 }
 
 // MasterSlaveRule is the default rule for "master-slave"
@@ -51,6 +69,9 @@ var MasterSlaveRule = Rule{
 	Name:         "master-slave",
 	Terms:        []string{"master-slave", "master/slave"},
 	Alternatives: []string{"leader/follower", "primary/replica", "primary/standby"},
+	Options: Options{
+		WordBoundary: false,
+	},
 }
 
 // SanityRule is the default rule for "sanity"
@@ -58,6 +79,9 @@ var SanityRule = Rule{
 	Name:         "sanity",
 	Terms:        []string{"sanity"},
 	Alternatives: []string{"confidence", "quick check", "coherence check"},
+	Options: Options{
+		WordBoundary: false,
+	},
 }
 
 // SlaveRule is the default rule for "slave"
@@ -65,6 +89,9 @@ var SlaveRule = Rule{
 	Name:         "slave",
 	Terms:        []string{"slave"},
 	Alternatives: []string{"follower", "replica", "standby"},
+	Options: Options{
+		WordBoundary: false,
+	},
 }
 
 // WhiteboxRule is the default rule for "whitebox"
@@ -72,6 +99,9 @@ var WhiteboxRule = Rule{
 	Name:         "whitebox",
 	Terms:        []string{"white-box", "whitebox", "white box"},
 	Alternatives: []string{"open-box"},
+	Options: Options{
+		WordBoundary: false,
+	},
 }
 
 // WhitelistRule is the default rule for "whitelist"
@@ -80,6 +110,9 @@ var WhitelistRule = Rule{
 	Terms:        []string{"whitelist", "white-list", "whitelisted", "white-listed"},
 	Alternatives: []string{"allowlist"},
 	Severity:     1,
+	Options: Options{
+		WordBoundary: false,
+	},
 }
 
 // DefaultRules are the default rules always used

--- a/pkg/rule/default_test.go
+++ b/pkg/rule/default_test.go
@@ -21,7 +21,7 @@ func TestDefaultRules(t *testing.T) {
 				assert.Len(t, r.FindMatchIndexes(fmt.Sprintf("other %s words %s before", term, term)), 2)
 				assert.Len(t, r.FindMatchIndexes(fmt.Sprintf("other %s words before %s", term, term)), 2)
 
-				assert.Len(t, r.FindMatchIndexes(fmt.Sprintf("other %s%s.", term, term)), 0)
+				assert.Len(t, r.FindMatchIndexes(fmt.Sprintf("other %s%s.", term, term)), 2)
 			})
 		}
 	}

--- a/pkg/rule/options.go
+++ b/pkg/rule/options.go
@@ -1,0 +1,5 @@
+package rule
+
+type Options struct {
+	WordBoundary bool `yaml:"word_boundary"`
+}

--- a/pkg/rule/rule_test.go
+++ b/pkg/rule/rule_test.go
@@ -10,18 +10,24 @@ import (
 func TestRule_FindMatchIndexes(t *testing.T) {
 	r := testRule()
 	tests := []struct {
-		text     string
-		expected [][]int
+		text       string
+		expected   [][]int
+		expectedWb [][]int
 	}{
-		{"this string has rule-1 and rule1 included", [][]int{{16, 22}, {27, 32}}},
-		{"this string has rule-2 and rule1 included", [][]int{{27, 32}}},
-		{"this string does not have any violations", [][]int(nil)},
-		{"this string has no violation due to word boundary rule1rule-1", [][]int(nil)},
-		// ^ This case should be a violation, but the code needs to be updated to support it.
+		{"this string has rule-1 and rule1 included", [][]int{{16, 22}, {27, 32}}, [][]int{{16, 22}, {27, 32}}},
+		{"this string has rule-2 and rule1 included", [][]int{{27, 32}}, [][]int{{27, 32}}},
+		{"this string does not have any violations", [][]int(nil), [][]int(nil)},
+		{"this string has violation with word boundary rule1rule-1", [][]int{{45, 50}, {50, 56}}, [][]int(nil)},
 	}
 	for _, test := range tests {
 		got := r.FindMatchIndexes(test.text)
 		assert.Equal(t, test.expected, got)
+	}
+
+	r.Options.WordBoundary = true
+	for _, test := range tests {
+		got := r.FindMatchIndexes(test.text)
+		assert.Equal(t, test.expectedWb, got)
 	}
 
 	e := Rule{Name: "rule1"}


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The commit message follows our [guidelines](https://github.com/get-woke/woke/blob/main/CONTRIBUTING.md)
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Feature


**What is the current behavior?** (You can also link to an open issue here)
Currently, all rules will trigger violations only if the terms match a regex with that is wrapped in a word boundary (`\b(term)\b`). This might lead to some missed violations. For example, `echo "SlaveOf" | woke --stdin` does not return a violation, but it should.


**What is the new behavior (if this is a feature change)?**
Make the word boundary configurable, disabled by default. This means, but default, all rules will not use the word boundary, but it can be abled on a per-rule basis. Filepath violations will continue to not use word boundary.


**Does this PR introduce a breaking change?** (What changes might users need to make due to this PR?)
No, but it may trigger more violations then previous versions

**Other information**:
