### PR TITLE
dev: Use an `io.Writer` for writing output

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -31,6 +31,7 @@ import (
 
 	"github.com/get-woke/woke/pkg/config"
 	"github.com/get-woke/woke/pkg/ignore"
+	"github.com/get-woke/woke/pkg/output"
 	"github.com/get-woke/woke/pkg/parser"
 	"github.com/get-woke/woke/pkg/printer"
 
@@ -45,7 +46,7 @@ var (
 	ruleConfig       string
 	debug            bool
 	stdin            bool
-	output           string
+	outputName       string
 	noIgnore         bool
 
 	// Version is populated by goreleaser during build
@@ -103,7 +104,7 @@ func rootRunE(cmd *cobra.Command, args []string) error {
 		args = []string{os.Stdin.Name()}
 	}
 
-	print, err := printer.NewPrinter(output)
+	print, err := printer.NewPrinter(outputName)
 	if err != nil {
 		return err
 	}
@@ -117,7 +118,7 @@ func rootRunE(cmd *cobra.Command, args []string) error {
 	}
 
 	if violations == 0 {
-		fmt.Println("No violations found. Stay woke \u270a")
+		fmt.Fprintln(output.Stdout, "No violations found. Stay woke \u270a")
 	}
 
 	return err
@@ -137,7 +138,7 @@ func init() {
 	rootCmd.PersistentFlags().BoolVar(&stdin, "stdin", false, "Read from stdin")
 	rootCmd.PersistentFlags().BoolVar(&debug, "debug", false, "Enable debug logging")
 	rootCmd.PersistentFlags().BoolVar(&noIgnore, "no-ignore", false, "Files matching entries in .gitignore/.wokeignore are parsed")
-	rootCmd.PersistentFlags().StringVarP(&output, "output", "o", printer.OutFormatText, fmt.Sprintf("Output type [%s]", printer.OutFormatsString))
+	rootCmd.PersistentFlags().StringVarP(&outputName, "output", "o", printer.OutFormatText, fmt.Sprintf("Output type [%s]", printer.OutFormatsString))
 }
 
 func setLogLevel() {

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -2,11 +2,10 @@ package cmd
 
 import (
 	"bytes"
-	"io"
-	"os"
 	"regexp"
-	"sync"
 	"testing"
+
+	"github.com/get-woke/woke/pkg/output"
 
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
@@ -25,53 +24,30 @@ func BenchmarkExecute(b *testing.B) {
 }
 
 func TestRunE(t *testing.T) {
+	origStdout := output.Stdout
 	t.Cleanup(func() {
 		exitOneOnFailure = false
 		noIgnore = false
+		// Reset back to original
+		output.Stdout = origStdout
 	})
+
 	t.Run("no violations found", func(t *testing.T) {
-		got := captureOutput(func() {
-			err := rootRunE(new(cobra.Command), []string{"../testdata/good.yml"})
-			assert.NoError(t, err)
-		})
+		buf := new(bytes.Buffer)
+		output.Stdout = buf
+
+		err := rootRunE(new(cobra.Command), []string{"../testdata/good.yml"})
+		assert.NoError(t, err)
+
+		got := buf.String()
 		expected := "No violations found. Stay woke \u270a\n"
 		assert.Equal(t, expected, got)
 	})
 	t.Run("violations w error", func(t *testing.T) {
 		exitOneOnFailure = true
+
 		err := rootRunE(new(cobra.Command), []string{"../testdata"})
 		assert.Error(t, err)
 		assert.Regexp(t, regexp.MustCompile(`^files with violations: \d`), err.Error())
 	})
-}
-
-// Returns output of `os.Stdout` as string.
-// Based on https://medium.com/@hau12a1/golang-capturing-log-println-and-fmt-println-output-770209c791b4
-func captureOutput(f func()) string {
-	reader, writer, err := os.Pipe()
-	if err != nil {
-		panic(err)
-	}
-	stdout := os.Stdout
-	stderr := os.Stderr
-	defer func() {
-		os.Stdout = stdout
-		os.Stderr = stderr
-	}()
-	os.Stdout = writer
-	os.Stderr = writer
-
-	out := make(chan string)
-	wg := new(sync.WaitGroup)
-	wg.Add(1)
-	go func() {
-		var buf bytes.Buffer
-		wg.Done()
-		_, _ = io.Copy(&buf, reader)
-		out <- buf.String()
-	}()
-	wg.Wait()
-	f()
-	writer.Close()
-	return <-out
 }

--- a/pkg/output/output.go
+++ b/pkg/output/output.go
@@ -1,0 +1,15 @@
+package output
+
+import "github.com/mattn/go-colorable"
+
+// These are the same as https://pkg.go.dev/github.com/fatih/color@v1.9.0#pkg-variables,
+// but a central place to access them within this codebase.
+// colorable package enables color support on Windows
+var (
+	// Stdout defines the standard output of the print functions. By default
+	// os.Stdout is used.
+	Stdout = colorable.NewColorableStdout()
+
+	// Stderr defines a color supporting writer for os.Stderr.
+	Stderr = colorable.NewColorableStderr()
+)

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 
 	"github.com/get-woke/woke/pkg/ignore"
+	"github.com/get-woke/woke/pkg/output"
 	"github.com/get-woke/woke/pkg/printer"
 	"github.com/get-woke/woke/pkg/result"
 	"github.com/get-woke/woke/pkg/rule"
@@ -46,7 +47,7 @@ func (p *Parser) ParsePaths(print printer.Printer, paths ...string) int {
 	if util.InSlice(os.Stdin.Name(), paths) {
 		r, _ := generateFileViolations(os.Stdin, p.Rules)
 		if r.Len() > 0 {
-			print.Print(r)
+			print.Print(output.Stdout, r)
 		}
 		return r.Len()
 	}
@@ -75,7 +76,7 @@ func (p *Parser) ParsePaths(print printer.Printer, paths ...string) int {
 	violations := 0
 	for r := range p.rchan {
 		sort.Sort(r)
-		print.Print(&r)
+		print.Print(output.Stdout, &r)
 		violations++
 	}
 	return violations

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -3,6 +3,7 @@ package parser
 import (
 	"fmt"
 	"go/token"
+	"io"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -20,7 +21,8 @@ type testPrinter struct {
 	results []*result.FileResults
 }
 
-func (p *testPrinter) Print(r *result.FileResults) error {
+// Print doesn't actually write anything, just stores the results in memory so they can be read later
+func (p *testPrinter) Print(_ io.Writer, r *result.FileResults) error {
 	p.results = append(p.results, r)
 	return nil
 }

--- a/pkg/printer/githubactions.go
+++ b/pkg/printer/githubactions.go
@@ -2,6 +2,7 @@ package printer
 
 import (
 	"fmt"
+	"io"
 
 	"github.com/get-woke/woke/pkg/result"
 	"github.com/get-woke/woke/pkg/rule"
@@ -17,9 +18,9 @@ func NewGitHubActions() *GitHubActions {
 
 // Print prints in the format for GitHub actions
 // https://docs.github.com/en/actions/reference/workflow-commands-for-github-actions#setting-an-error-message
-func (p *GitHubActions) Print(fs *result.FileResults) error {
+func (p *GitHubActions) Print(w io.Writer, fs *result.FileResults) error {
 	for _, r := range fs.Results {
-		fmt.Println(formatResultForGitHubAction(r))
+		fmt.Fprintln(w, formatResultForGitHubAction(r))
 	}
 	return nil
 }

--- a/pkg/printer/githubactions_test.go
+++ b/pkg/printer/githubactions_test.go
@@ -1,6 +1,7 @@
 package printer
 
 import (
+	"bytes"
 	"fmt"
 	"go/token"
 	"testing"
@@ -41,9 +42,9 @@ func TestTranslateSeverityForAction(t *testing.T) {
 func TestGitHubActions_Print(t *testing.T) {
 	p := NewGitHubActions()
 	res := generateFileResult()
-	got := captureOutput(func() {
-		assert.NoError(t, p.Print(res))
-	})
+	buf := new(bytes.Buffer)
+	assert.NoError(t, p.Print(buf, res))
+	got := buf.String()
 	expected := fmt.Sprintf("::warning file=foo.txt,line=1,col=6::%s\n", res.Results[0].Reason())
 	assert.Equal(t, expected, got)
 }

--- a/pkg/printer/json.go
+++ b/pkg/printer/json.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
 
 	"github.com/get-woke/woke/pkg/result"
 )
@@ -20,9 +21,9 @@ func NewJSON() *JSON {
 // NOTE: The JSON printer will bring each line result as a JSON string.
 // It will not be presented as an array of FileResults. You will neeed to
 // Split by new line to parse the full output
-func (p *JSON) Print(fs *result.FileResults) error {
+func (p *JSON) Print(w io.Writer, fs *result.FileResults) error {
 	var buf bytes.Buffer
 	err := json.NewEncoder(&buf).Encode(fs)
-	fmt.Print(buf.String()) // json Encoder already puts a new line in, so no need for Println here
+	fmt.Fprint(w, buf.String()) // json Encoder already puts a new line in, so no need for Println here
 	return err
 }

--- a/pkg/printer/json_test.go
+++ b/pkg/printer/json_test.go
@@ -1,6 +1,7 @@
 package printer
 
 import (
+	"bytes"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -9,9 +10,10 @@ import (
 func TestJSON_Print(t *testing.T) {
 	p := NewJSON()
 	res := generateFileResult()
-	got := captureOutput(func() {
-		assert.NoError(t, p.Print(res))
-	})
+	buf := new(bytes.Buffer)
+	assert.NoError(t, p.Print(buf, res))
+	got := buf.String()
+
 	expected := `{"Filename":"foo.txt","Results":[{"Rule":{"Name":"blacklist","Terms":["blacklist","black-list","blacklisted","black-listed"],"Alternatives":["denylist","blocklist"],"Note":"","Severity":"warning","Options":{"WordBoundary":false}},"Violation":"blacklist","Line":"this blacklist must change","StartPosition":{"Filename":"foo.txt","Offset":0,"Line":1,"Column":6},"EndPosition":{"Filename":"foo.txt","Offset":0,"Line":1,"Column":15},"Reason":"` + "`blacklist`" + ` may be insensitive, use ` + "`denylist`" + `, ` + "`blocklist`" + ` instead"}]}` + "\n"
 	assert.Equal(t, expected, got)
 }

--- a/pkg/printer/printer.go
+++ b/pkg/printer/printer.go
@@ -2,6 +2,7 @@ package printer
 
 import (
 	"fmt"
+	"io"
 	"strings"
 
 	"github.com/get-woke/woke/pkg/result"
@@ -12,7 +13,7 @@ import (
 
 // Printer is an interface for printing FileResults
 type Printer interface {
-	Print(*result.FileResults) error
+	Print(io.Writer, *result.FileResults) error
 }
 
 const (

--- a/pkg/printer/simple.go
+++ b/pkg/printer/simple.go
@@ -3,6 +3,7 @@ package printer
 import (
 	"fmt"
 	"go/token"
+	"io"
 
 	"github.com/get-woke/woke/pkg/result"
 )
@@ -17,9 +18,9 @@ func NewSimple() *Simple {
 
 // Print prints in the format 'filename:line:column: message'
 // based on golint's output: https://github.com/golang/lint/blob/738671d3881b9731cc63024d5d88cf28db875626/golint/golint.go#L121
-func (p *Simple) Print(fs *result.FileResults) error {
+func (p *Simple) Print(w io.Writer, fs *result.FileResults) error {
 	for _, r := range fs.Results {
-		fmt.Printf("%v: [%s] %s\n",
+		fmt.Fprintf(w, "%v: [%s] %s\n",
 			positionString(r.GetStartPosition()),
 			r.GetSeverity(),
 			r.Reason())

--- a/pkg/printer/simple_test.go
+++ b/pkg/printer/simple_test.go
@@ -1,6 +1,7 @@
 package printer
 
 import (
+	"bytes"
 	"fmt"
 	"go/token"
 	"testing"
@@ -40,9 +41,9 @@ func TestSimple_positionString(t *testing.T) {
 func TestSimple_Print(t *testing.T) {
 	p := NewSimple()
 	res := generateFileResult()
-	got := captureOutput(func() {
-		assert.NoError(t, p.Print(res))
-	})
+	buf := new(bytes.Buffer)
+	assert.NoError(t, p.Print(buf, res))
+	got := buf.String()
 	expected := fmt.Sprintf("foo.txt:1:6: [warning] %s\n", res.Results[0].Reason())
 	assert.Equal(t, expected, got)
 }

--- a/pkg/printer/text.go
+++ b/pkg/printer/text.go
@@ -2,11 +2,11 @@ package printer
 
 import (
 	"fmt"
+	"io"
 
 	"github.com/get-woke/woke/pkg/result"
 
 	"github.com/fatih/color"
-	"github.com/mattn/go-colorable"
 )
 
 // Text is a text printer meant for humans to read
@@ -22,20 +22,20 @@ func NewText(disableColor bool) *Text {
 }
 
 // Print prints the file results
-func (t *Text) Print(fs *result.FileResults) error {
+func (t *Text) Print(w io.Writer, fs *result.FileResults) error {
 	if t.disableColor {
 		color.NoColor = true
 	}
-
-	output := colorable.NewColorableStdout()
 
 	for _, r := range fs.Results {
 		pos := fmt.Sprintf("%d:%d-%d",
 			r.GetStartPosition().Line,
 			r.GetStartPosition().Column,
 			r.GetEndPosition().Column)
+
 		sev := r.GetSeverity()
-		fmt.Fprintf(output, "%s:%s: %s (%s)\n",
+
+		fmt.Fprintf(w, "%s:%s: %s (%s)\n",
 			color.New(color.Bold, color.FgHiCyan).Sprint(fs.Filename),
 			color.New(color.Bold).Sprint(pos),
 			color.New(color.FgHiMagenta).Sprint(r.Reason()),
@@ -44,8 +44,8 @@ func (t *Text) Print(fs *result.FileResults) error {
 		// If the line empty, skip showing the source code
 		// This could happen if the line is too long to be worth showing
 		if len(r.GetLine()) > 0 {
-			fmt.Fprintln(output, r.GetLine())
-			fmt.Fprintf(output, "%s\n", t.arrowUnderLine(r))
+			fmt.Fprintln(w, r.GetLine())
+			fmt.Fprintln(w, t.arrowUnderLine(r))
 		}
 	}
 

--- a/pkg/printer/text_test.go
+++ b/pkg/printer/text_test.go
@@ -1,6 +1,7 @@
 package printer
 
 import (
+	"bytes"
 	"fmt"
 	"testing"
 
@@ -12,9 +13,9 @@ import (
 func TestText_Print(t *testing.T) {
 	p := NewText(true)
 	res := generateFileResult()
-	got := captureOutput(func() {
-		assert.NoError(t, p.Print(res))
-	})
+	buf := new(bytes.Buffer)
+	assert.NoError(t, p.Print(buf, res))
+	got := buf.String()
 	expected := fmt.Sprintf("foo.txt:1:6-15: %s (%s)\n%s\n      ^\n", res.Results[0].Reason(), res.Results[0].GetSeverity(), res.Results[0].GetLine())
 	assert.Equal(t, expected, got)
 }

--- a/pkg/printer/util_test.go
+++ b/pkg/printer/util_test.go
@@ -1,11 +1,7 @@
 package printer
 
 import (
-	"bytes"
 	"go/token"
-	"io"
-	"os"
-	"sync"
 
 	"github.com/get-woke/woke/pkg/result"
 	"github.com/get-woke/woke/pkg/rule"
@@ -37,37 +33,6 @@ func generateResults(filename string) []result.Result {
 			},
 		},
 	}
-}
-
-// Returns output of `os.Stdout` as string.
-// Based on https://medium.com/@hau12a1/golang-capturing-log-println-and-fmt-println-output-770209c791b4
-func captureOutput(f func()) string {
-	reader, writer, err := os.Pipe()
-	if err != nil {
-		panic(err)
-	}
-	stdout := os.Stdout
-	stderr := os.Stderr
-	defer func() {
-		os.Stdout = stdout
-		os.Stderr = stderr
-	}()
-	os.Stdout = writer
-	os.Stderr = writer
-
-	out := make(chan string)
-	wg := new(sync.WaitGroup)
-	wg.Add(1)
-	go func() {
-		var buf bytes.Buffer
-		wg.Done()
-		_, _ = io.Copy(&buf, reader)
-		out <- buf.String()
-	}()
-	wg.Wait()
-	f()
-	writer.Close()
-	return <-out
 }
 
 func newPosition(f string, l, c int) *token.Position {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The commit message follows our [guidelines](https://github.com/get-woke/woke/blob/main/CONTRIBUTING.md)
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
No longer assume `os.Stdout` is where output will be written to. Use `fmt.Fprint` for printing output. This also helps make tests cleaner as to not need to try to capture stdout.



**What is the current behavior?** (You can also link to an open issue here)
The code assumes `os.Stdout`, via `fmt.Print` or `color.Output` (for Windows color support). This makes some tests more difficult to deal with, needing to have a special function for capturing stdout.



**What is the new behavior (if this is a feature change)?**
Explicit and customizable output


**Does this PR introduce a breaking change?** (What changes might users need to make because of this PR?)
No

**Other information**:
