### PR TITLE
Fix triggering violations within a `wokeignore` inline ignore comment

### DIFF
--- a/pkg/parser/violations_test.go
+++ b/pkg/parser/violations_test.go
@@ -97,3 +97,26 @@ func newFileWithPrefix(t *testing.T, prefix, text string) (*os.File, error) {
 
 	return tmpFile, err
 }
+
+// Tests for when a rule name is used with inline wokeignore, when that rule name matches another rule
+func TestGenerateFileViolationsOverlappingRules(t *testing.T) {
+	tests := []struct {
+		desc    string
+		content string
+		matches int
+	}{
+		{"overlapping rule", "this has master #wokeignore:rule=master-slave", 0},
+		{"overlapping rule two ignores", "this has master #wokeignore:rule=master-slave,slave", 0},
+		{"wrong rule", "this has whitelist # wokeignore:rule=blacklist", 1},
+	}
+	for _, tc := range tests {
+		t.Run(tc.desc, func(t *testing.T) {
+			f, err := newFile(t, tc.content)
+			assert.NoError(t, err)
+
+			res, err := generateFileViolationsFromFilename(f.Name(), rule.DefaultRules)
+			assert.NoError(t, err)
+			assert.Len(t, res.Results, tc.matches)
+		})
+	}
+}

--- a/pkg/rule/rule.go
+++ b/pkg/rule/rule.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"regexp"
 	"strings"
+	"unicode"
 
 	"github.com/get-woke/woke/pkg/util"
 )
@@ -37,7 +38,9 @@ func (r *Rule) FindMatchIndexes(text string) [][]int {
 	}
 
 	r.SetRegexp()
-	matches := r.findAllStringSubmatchIndex(text)
+
+	// Remove inline ignores from text to avoid matching against other rules
+	matches := r.findAllStringSubmatchIndex(removeInlineIgnore(text))
 	if matches == nil {
 		return [][]int(nil)
 	}
@@ -158,6 +161,27 @@ func escape(ss []string) []string {
 		ss[i] = regexp.QuoteMeta(s)
 	}
 	return ss
+}
+
+// removeInlineIgnore removes the entire match of the ignoreRuleRegex from the line
+// and replaces it with the unicode replacement character so the rule matcher won't
+// attempt to find violations within
+func removeInlineIgnore(line string) string {
+	inlineIgnoreMatch := ignoreRuleRegex.FindStringIndex(line)
+	if inlineIgnoreMatch == nil || len(inlineIgnoreMatch) < 2 {
+		return line
+	}
+
+	lineWithoutIgnoreRule := []rune(line)
+
+	start := inlineIgnoreMatch[0]
+	end := inlineIgnoreMatch[1]
+
+	for i := start; i < end; i++ {
+		lineWithoutIgnoreRule[i] = unicode.ReplacementChar
+	}
+
+	return string(lineWithoutIgnoreRule)
 }
 
 // Disabled denotes if the rule is disabled

--- a/pkg/rule/rule_test.go
+++ b/pkg/rule/rule_test.go
@@ -130,3 +130,27 @@ func TestRule_EmptyTerms(t *testing.T) {
 		})
 	}
 }
+
+func Test_removeInlineIgnore(t *testing.T) {
+	tests := []struct {
+		desc     string
+		line     string
+		expected string
+	}{
+		{
+			desc:     "replace wokeignore:rule",
+			line:     "wokeignore:rule=master-slave",
+			expected: "����������������������������",
+		},
+		{
+			desc:     "not replace wokeignore:rule",
+			line:     "no inline ignore",
+			expected: "no inline ignore",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			assert.Equal(t, tt.expected, removeInlineIgnore(tt.line))
+		})
+	}
+}


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The commit message follows our [guidelines](https://github.com/get-woke/woke/blob/main/CONTRIBUTING.md)
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix


**What is the current behavior?** (You can also link to an open issue here)
Fixes #41 


**What is the new behavior (if this is a feature change)?**
Matches to `wokeignore:rule=rulename` are removed from each line prior to processing it for violations. This will avoid triggering violations where rule A is ignored via an in-line ignore, but rule AB is triggered because it has A in its name.

The solution is to replace the entire `wokeignore:rule=rulename` within the line with the unicode replacement character `�` when it is processed for violations.

I also ran the test introduced in this PR `TestGenerateFileViolationsOverlappingRules` on the main branch and confirm the test fails. It passes on this PR


**Does this PR introduce a breaking change?** (What changes might users need to make due to this PR?)
No

**Other information**:
