### PR TITLE
test: Run PR tests using go 1.15

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -9,7 +9,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.14.x]
+        go-version: [1.15.x]
         os: [ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     name: Tests
@@ -41,7 +41,7 @@ jobs:
     name: Build
     strategy:
       matrix:
-        go-version: [1.14.x]
+        go-version: [1.15.x]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -80,7 +80,7 @@ jobs:
   lint:
     strategy:
       matrix:
-        go-version: [1.14.x]
+        go-version: [1.15.x]
     name: Lint
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The commit message follows our [guidelines](https://github.com/get-woke/woke/blob/main/CONTRIBUTING.md)
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Switch go PR tests to go 1.15 to match what's defined in [`go.mod`](https://github.com/get-woke/woke/blob/50eee28c92b81228523c1f413c41f89a675ca8c8/go.mod#L3)


**What is the current behavior?** (You can also link to an open issue here)
Everywhere else is using go 1.15, but the PR tests were never updated.


**What is the new behavior (if this is a feature change)?**



**Does this PR introduce a breaking change?** (What changes might users need to make due to this PR?)
No

**Other information**:
