### PR TITLE
Include inline ignored violations when `--no-ignore` flag is used

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ Flags:
       --debug               Enable debug logging
       --exit-1-on-failure   Exit with exit code 1 on failures
   -h, --help                help for woke
-      --no-ignore           Files matching entries in .gitignore/.wokeignore are parsed
+      --no-ignore           Ignored files in .gitignore/.wokeignore and inline ignores are processed
   -o, --output string       Output type [text,simple,github-actions,json] (default "text")
       --stdin               Read from stdin
   -v, --version             version for woke

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -132,7 +132,7 @@ func init() {
 	rootCmd.PersistentFlags().BoolVar(&exitOneOnFailure, "exit-1-on-failure", false, "Exit with exit code 1 on failures")
 	rootCmd.PersistentFlags().BoolVar(&stdin, "stdin", false, "Read from stdin")
 	rootCmd.PersistentFlags().BoolVar(&debug, "debug", false, "Enable debug logging")
-	rootCmd.PersistentFlags().BoolVar(&noIgnore, "no-ignore", false, "Files matching entries in .gitignore/.wokeignore are parsed")
+	rootCmd.PersistentFlags().BoolVar(&noIgnore, "no-ignore", false, "Ignored files in .gitignore/.wokeignore and inline ignores are processed")
 	rootCmd.PersistentFlags().StringVarP(&outputName, "output", "o", printer.OutFormatText, fmt.Sprintf("Output type [%s]", printer.OutFormatsString))
 }
 

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -45,7 +45,7 @@ func NewParser(rules []*rule.Rule, ignorer *ignore.Ignore) *Parser {
 func (p *Parser) ParsePaths(print printer.Printer, paths ...string) int {
 	// data provided through stdin
 	if util.InSlice(os.Stdin.Name(), paths) {
-		r, _ := generateFileViolations(os.Stdin, p.Rules)
+		r, _ := p.generateFileViolations(os.Stdin)
 		if r.Len() > 0 {
 			print.Print(output.Stdout, r)
 		}
@@ -88,7 +88,7 @@ func (p *Parser) processFiles(files <-chan string, done chan bool, wg *sync.Wait
 		go func(f string) {
 			defer wg.Done()
 
-			v, _ := generateFileViolationsFromFilename(f, p.Rules)
+			v, _ := p.generateFileViolationsFromFilename(f)
 			if v == nil || len(v.Results) == 0 {
 				return
 			}

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -122,6 +122,33 @@ func parsePathTests(t *testing.T) {
 		assert.Equal(t, len(pr.results), violations)
 	})
 
+	t.Run("ignored inline", func(t *testing.T) {
+		f, err := newFile(t, "i have a whitelist violation, but am ignored # wokeignore:rule=whitelist\n")
+		assert.NoError(t, err)
+
+		p := testParser()
+		pr := new(testPrinter)
+
+		violations := p.ParsePaths(pr, f.Name())
+		assert.NoError(t, err)
+		assert.Len(t, pr.results, 0)
+		assert.Equal(t, len(pr.results), violations)
+	})
+
+	t.Run("ignored inline with no ignorer", func(t *testing.T) {
+		f, err := newFile(t, "i have a whitelist violation, but am ignored # wokeignore:rule=whitelist\n")
+		assert.NoError(t, err)
+
+		p := testParser()
+		p.Ignorer = nil
+		pr := new(testPrinter)
+
+		violations := p.ParsePaths(pr, f.Name())
+		assert.NoError(t, err)
+		assert.Len(t, pr.results, 1)
+		assert.Equal(t, len(pr.results), violations)
+	})
+
 	t.Run("default path", func(t *testing.T) {
 		// Test default path (which would run tests against the parser package)
 		p := testParser()

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -1,7 +1,6 @@
 package parser
 
 import (
-	"fmt"
 	"go/token"
 	"io"
 	"io/ioutil"
@@ -35,10 +34,10 @@ func parsePathTests(t *testing.T) {
 	t.Run("violation", func(t *testing.T) {
 		f, err := newFile(t, "i have a whitelist")
 		assert.NoError(t, err)
+
 		pr := new(testPrinter)
 		p := testParser()
 		violations := p.ParsePaths(pr, f.Name())
-
 		assert.Len(t, pr.results, 1)
 		assert.Equal(t, len(pr.results), violations)
 
@@ -75,8 +74,6 @@ func parsePathTests(t *testing.T) {
 		p := testParser()
 		pr := new(testPrinter)
 		violations := p.ParsePaths(pr, f.Name())
-
-		assert.NoError(t, err)
 		assert.Len(t, pr.results, 0)
 		assert.Equal(t, len(pr.results), violations)
 	})
@@ -87,7 +84,6 @@ func parsePathTests(t *testing.T) {
 		p := testParser()
 		pr := new(testPrinter)
 		violations := p.ParsePaths(pr, f.Name())
-		assert.NoError(t, err)
 		assert.Len(t, pr.results, 0)
 		assert.Equal(t, len(pr.results), violations)
 	})
@@ -102,8 +98,6 @@ func parsePathTests(t *testing.T) {
 		p := testParser()
 		pr := new(testPrinter)
 		violations := p.ParsePaths(pr, f1.Name(), f2.Name())
-		assert.NoError(t, err)
-		fmt.Println(pr.results)
 		assert.Len(t, pr.results, 1)
 		assert.Equal(t, len(pr.results), violations)
 	})
@@ -117,7 +111,6 @@ func parsePathTests(t *testing.T) {
 		pr := new(testPrinter)
 
 		violations := p.ParsePaths(pr, f.Name())
-		assert.NoError(t, err)
 		assert.Len(t, pr.results, 0)
 		assert.Equal(t, len(pr.results), violations)
 	})
@@ -130,7 +123,6 @@ func parsePathTests(t *testing.T) {
 		pr := new(testPrinter)
 
 		violations := p.ParsePaths(pr, f.Name())
-		assert.NoError(t, err)
 		assert.Len(t, pr.results, 0)
 		assert.Equal(t, len(pr.results), violations)
 	})
@@ -144,7 +136,6 @@ func parsePathTests(t *testing.T) {
 		pr := new(testPrinter)
 
 		violations := p.ParsePaths(pr, f.Name())
-		assert.NoError(t, err)
 		assert.Len(t, pr.results, 1)
 		assert.Equal(t, len(pr.results), violations)
 	})

--- a/pkg/parser/violations.go
+++ b/pkg/parser/violations.go
@@ -54,6 +54,15 @@ Loop:
 			text = strings.TrimSuffix(text, "\n")
 
 			for _, r := range p.Rules {
+				if p.Ignorer != nil && r.CanIgnoreLine(text) {
+					log.Debug().
+						Str("rule", r.Name).
+						Str("file", filename).
+						Int("line", line).
+						Msg("ignoring via in-line")
+					continue
+				}
+
 				lineResults := result.FindResults(r, results.Filename, text, line)
 				results.Results = append(results.Results, lineResults...)
 			}

--- a/pkg/parser/violations_test.go
+++ b/pkg/parser/violations_test.go
@@ -30,8 +30,8 @@ func TestGenerateFileViolations(t *testing.T) {
 		t.Run(tc.desc, func(t *testing.T) {
 			f, err := newFile(t, tc.content)
 			assert.NoError(t, err)
-
-			res, err := generateFileViolationsFromFilename(f.Name(), rule.DefaultRules)
+			p := testParser()
+			res, err := p.generateFileViolationsFromFilename(f.Name())
 			assert.NoError(t, err)
 
 			filename := filepath.ToSlash(f.Name())
@@ -60,7 +60,8 @@ func TestGenerateFileViolations(t *testing.T) {
 		})
 	}
 	t.Run("missing file", func(t *testing.T) {
-		_, err := generateFileViolationsFromFilename("missing.file", rule.DefaultRules)
+		p := testParser()
+		_, err := p.generateFileViolationsFromFilename("missing.file")
 		assert.Error(t, err)
 	})
 
@@ -68,7 +69,8 @@ func TestGenerateFileViolations(t *testing.T) {
 		f, err := newFileWithPrefix(t, "whitelist-", "content")
 		assert.NoError(t, err)
 
-		res, err := generateFileViolationsFromFilename(f.Name(), rule.DefaultRules)
+		p := testParser()
+		res, err := p.generateFileViolationsFromFilename(f.Name())
 		assert.NoError(t, err)
 		assert.Len(t, res.Results, 1)
 		assert.Regexp(t, "^Filename violation: ", res.Results[0].Reason())
@@ -114,7 +116,8 @@ func TestGenerateFileViolationsOverlappingRules(t *testing.T) {
 			f, err := newFile(t, tc.content)
 			assert.NoError(t, err)
 
-			res, err := generateFileViolationsFromFilename(f.Name(), rule.DefaultRules)
+			p := testParser()
+			res, err := p.generateFileViolationsFromFilename(f.Name())
 			assert.NoError(t, err)
 			assert.Len(t, res.Results, tc.matches)
 		})

--- a/pkg/result/lineresult.go
+++ b/pkg/result/lineresult.go
@@ -6,8 +6,6 @@ import (
 	"go/token"
 
 	"github.com/get-woke/woke/pkg/rule"
-
-	"github.com/rs/zerolog/log"
 )
 
 // MaxLineLength is the max line length that this printer
@@ -47,15 +45,6 @@ func NewLineResult(r *rule.Rule, violation, filename string, line, startColumn, 
 // FindResults returns the results that match the rule for the given text.
 // filename and line are only used for the Position
 func FindResults(r *rule.Rule, filename, text string, line int) (rs []Result) {
-	if r.CanIgnoreLine(text) {
-		log.Debug().
-			Str("rule", r.Name).
-			Str("file", filename).
-			Int("line", line).
-			Msg("ignoring via in-line")
-		return
-	}
-
 	idxs := r.FindMatchIndexes(text)
 
 	for _, idx := range idxs {

--- a/pkg/result/lineresult_test.go
+++ b/pkg/result/lineresult_test.go
@@ -19,8 +19,9 @@ func TestFindResults(t *testing.T) {
 	rs = FindResults(&rule.WhitelistRule, "my/file", "this has no rule violations", 1)
 	assert.Len(t, rs, 0)
 
+	// inline-ignoring is handled in Parser.generateFileViolations, not FindResults
 	rs = FindResults(&rule.WhitelistRule, "my/file", "this has the term whitelist #wokeignore:rule=whitelist", 1)
-	assert.Len(t, rs, 0)
+	assert.Len(t, rs, 1)
 }
 
 func TestLineResult_MarshalJSON(t *testing.T) {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The commit message follows our [guidelines](https://github.com/get-woke/woke/blob/main/CONTRIBUTING.md)
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix


**What is the current behavior?** (You can also link to an open issue here)
Running woke with `--no-ignore` processes ignored files, but continues to skip inline ignores. Fixes #54 


**What is the new behavior (if this is a feature change)?**
Running `woke --no-ignore` now processes both ignored files and inline ignores



**Does this PR introduce a breaking change?** (What changes might users need to make due to this PR?)
Lines ignored with an inline ignore will now be processed when using the `--no-ignore` flag

**Other information**:
