### PR TITLE
Adding 'master' by itself

### DIFF
--- a/pkg/rule/default.yaml
+++ b/pkg/rule/default.yaml
@@ -37,6 +37,14 @@
     - follower
     - replica
     - standby
+    
+- name: master
+  terms:
+    - master
+  alternatives:
+    - primary
+    - main
+    - default
 
 - name: grandfathered
   terms:


### PR DESCRIPTION
The list includes 'master-slave' but does not include 'master' by itself.  I think that it should.  

https://inclusivenaming.org/language/word-list/
https://github.com/github/renaming

Signed-off-by: John Bent <john.bent@seagate.com>

**Please check if the PR fulfills these requirements**

- [ ] The commit message follows our [guidelines](https://github.com/get-woke/woke/blob/main/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)



**What is the current behavior?** (You can also link to an open issue here)



**What is the new behavior (if this is a feature change)?**



**Does this PR introduce a breaking change?** (What changes might users need to make due to this PR?)


**Other information**:
