### PR TITLE
Add support for a custom success error message.

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -112,11 +112,9 @@ func rootRunE(cmd *cobra.Command, args []string) error {
 	}
 
 	if violations == 0 {
-		successExitMessage := "No violations found. Stay woke \u270a"
-		if cfg.SuccessExitMessage != "" {
-			successExitMessage = cfg.SuccessExitMessage
+		if cfg.GetSuccessExitMessage() != "" {
+			fmt.Fprintln(output.Stdout, cfg.GetSuccessExitMessage())
 		}
-		fmt.Fprintln(output.Stdout, successExitMessage)
 	}
 
 	return err

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -112,7 +112,11 @@ func rootRunE(cmd *cobra.Command, args []string) error {
 	}
 
 	if violations == 0 {
-		fmt.Fprintln(output.Stdout, "No violations found. Stay woke \u270a")
+		successExitMessage := "No violations found. Stay woke \u270a"
+		if cfg.SuccessExitMessage != "" {
+			successExitMessage = cfg.SuccessExitMessage
+		}
+		fmt.Fprintln(output.Stdout, successExitMessage)
 	}
 
 	return err

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -8,9 +8,9 @@ import (
 
 	"github.com/get-woke/woke/pkg/output"
 	"github.com/get-woke/woke/pkg/parser"
-	"github.com/spf13/viper"
 
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/get-woke/woke/pkg/output"
 	"github.com/get-woke/woke/pkg/parser"
+	"github.com/spf13/viper"
 
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
@@ -56,11 +57,13 @@ func TestParseArgs(t *testing.T) {
 
 func TestRunE(t *testing.T) {
 	origStdout := output.Stdout
+	origConfigFile := viper.ConfigFileUsed()
 	t.Cleanup(func() {
 		exitOneOnFailure = false
 		noIgnore = false
 		// Reset back to original
 		output.Stdout = origStdout
+		viper.SetConfigName(origConfigFile)
 	})
 
 	t.Run("no violations found", func(t *testing.T) {
@@ -74,6 +77,20 @@ func TestRunE(t *testing.T) {
 		expected := "No violations found. Stay woke \u270a\n"
 		assert.Equal(t, expected, got)
 	})
+
+	t.Run("no violations found with custom message", func(t *testing.T) {
+		buf := new(bytes.Buffer)
+		output.Stdout = buf
+
+		viper.SetConfigFile("../testdata/.woke-custom-exit-success.yaml")
+		err := rootRunE(new(cobra.Command), []string{"../testdata/good.yml"})
+		assert.NoError(t, err)
+
+		got := buf.String()
+		expected := "this is a test\n"
+		assert.Equal(t, expected, got)
+	})
+
 	t.Run("violations w error", func(t *testing.T) {
 		exitOneOnFailure = true
 

--- a/example.yaml
+++ b/example.yaml
@@ -21,4 +21,5 @@ rules:
     severity: warning
 
 # optional if you want to have a custom success message
+# you can also set this to an empty string `""` to output no message at all
 # success_exit_message: No violations found

--- a/example.yaml
+++ b/example.yaml
@@ -19,3 +19,6 @@ rules:
       - denylist
       - blocklist
     severity: warning
+
+# optional if you want to have a custom success message
+# success_exit_message: No violations found

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -14,8 +14,9 @@ import (
 
 // Config contains a list of rules
 type Config struct {
-	Rules       []*rule.Rule `yaml:"rules"`
-	IgnoreFiles []string     `yaml:"ignore_files"`
+	Rules              []*rule.Rule `yaml:"rules"`
+	IgnoreFiles        []string     `yaml:"ignore_files"`
+	SuccessExitMessage string       `yaml:"success_exit_message"`
 }
 
 // NewConfig returns a new Config

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -16,7 +16,7 @@ import (
 type Config struct {
 	Rules              []*rule.Rule `yaml:"rules"`
 	IgnoreFiles        []string     `yaml:"ignore_files"`
-	SuccessExitMessage string       `yaml:"success_exit_message"`
+	SuccessExitMessage *string      `yaml:"success_exit_message"`
 }
 
 // NewConfig returns a new Config
@@ -47,6 +47,13 @@ func NewConfig(filename string) (*Config, error) {
 	}
 
 	return &c, nil
+}
+
+func (c *Config) GetSuccessExitMessage() string {
+	if c.SuccessExitMessage == nil {
+		return "No violations found. Stay woke ✊"
+	}
+	return *c.SuccessExitMessage
 }
 
 func (c *Config) inExistingRules(r *rule.Rule) bool {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -64,6 +64,9 @@ func TestNewConfig(t *testing.T) {
 		expected.ConfigureRules()
 
 		assert.EqualValues(t, expected.Rules, c.Rules)
+
+		// check default config message
+		assert.Equal(t, "No violations found. Stay woke ✊", c.GetSuccessExitMessage())
 	})
 
 	t.Run("config-empty-missing", func(t *testing.T) {
@@ -83,6 +86,24 @@ func TestNewConfig(t *testing.T) {
 		c, err := NewConfig("testdata/missing.yaml")
 		assert.Error(t, err)
 		assert.Nil(t, c)
+	})
+
+	t.Run("config-empty-success-message", func(t *testing.T) {
+		// Test when no config file is provided
+		c, err := NewConfig("testdata/empty-success-message.yaml")
+		assert.NoError(t, err)
+
+		// check default config message
+		assert.Equal(t, "", c.GetSuccessExitMessage())
+	})
+
+	t.Run("config-custom-success-message", func(t *testing.T) {
+		// Test when no config file is provided
+		c, err := NewConfig("testdata/custom-success-message.yaml")
+		assert.NoError(t, err)
+
+		// check default config message
+		assert.Equal(t, "this is a test", c.GetSuccessExitMessage())
 	})
 }
 

--- a/pkg/config/testdata/custom-success-message.yaml
+++ b/pkg/config/testdata/custom-success-message.yaml
@@ -1,0 +1,13 @@
+ignore_files:
+  - README.md
+  - pkg/rule/default.go
+
+rules:
+  - name: rule1
+    terms:
+      - rule1
+    alternatives:
+      - alt-rule1
+    severity: warning
+
+success_exit_message: this is a test

--- a/pkg/config/testdata/empty-success-message.yaml
+++ b/pkg/config/testdata/empty-success-message.yaml
@@ -1,0 +1,13 @@
+ignore_files:
+  - README.md
+  - pkg/rule/default.go
+
+rules:
+  - name: rule1
+    terms:
+      - rule1
+    alternatives:
+      - alt-rule1
+    severity: warning
+
+success_exit_message: ""

--- a/testdata/.woke-custom-exit-success.yaml
+++ b/testdata/.woke-custom-exit-success.yaml
@@ -1,0 +1,1 @@
+success_exit_message: this is a test


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The commit message follows our [guidelines](https://github.com/get-woke/woke/blob/main/CONTRIBUTING.md)
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Feature


**What is the current behavior?** (You can also link to an open issue here)
Currently the success message is statically set to `"No violations found. Stay woke \u270a"`


**What is the new behavior (if this is a feature change)?**
This allows users to personalize their response when no violations are found using the config file via the optional `success_exit_message`.

**Does this PR introduce a breaking change?** (What changes might users need to make due to this PR?)
Non-breaking change.

**Other information**:
