### PR TITLE
Add rule note to output message

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,8 +207,10 @@ rules:
       - white-list
     alternatives:
       - allowlist
+    note: An optional description why these terms are not inclusive. It can be optionally included in the output message. 
     # options:
     #   word_boundary: false
+    #   add_note_to_message: false
 ```
 
 #### Options
@@ -220,6 +222,10 @@ Current options include:
 - `word_boundary` (default: `false`)
   - If `true`, terms will trigger violations when they are surrounded by ASCII word boundaries.
   - If `false`, will trigger violations if the term if found anywhere in the line, regardless if it is within an ASCII word boundary.
+- `add_note_to_message` (default: `not set`)
+  - If `true`, the rule note will be included in the output message explaining why this violation is not inclusive
+  - If `false`, the rule note will not be included in the output message
+  - If `not set`, `add_note_to_message` in your `woke` config file (ie `.woke.yml`) regulates if the note should be included in the output message (default: `false`). 
 
 #### Disabling Default Rules
 

--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ rules:
     note: An optional description why these terms are not inclusive. It can be optionally included in the output message. 
     # options:
     #   word_boundary: false
-    #   add_note_to_message: false
+    #   include_note: false
 ```
 
 #### Options
@@ -222,10 +222,10 @@ Current options include:
 - `word_boundary` (default: `false`)
   - If `true`, terms will trigger violations when they are surrounded by ASCII word boundaries.
   - If `false`, will trigger violations if the term if found anywhere in the line, regardless if it is within an ASCII word boundary.
-- `add_note_to_message` (default: `not set`)
+- `include_note` (default: `not set`)
   - If `true`, the rule note will be included in the output message explaining why this violation is not inclusive
   - If `false`, the rule note will not be included in the output message
-  - If `not set`, `add_note_to_message` in your `woke` config file (ie `.woke.yml`) regulates if the note should be included in the output message (default: `false`). 
+  - If `not set`, `include_note` in your `woke` config file (ie `.woke.yml`) regulates if the note should be included in the output message (default: `false`). 
 
 #### Disabling Default Rules
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -17,7 +17,7 @@ type Config struct {
 	Rules              []*rule.Rule `yaml:"rules"`
 	IgnoreFiles        []string     `yaml:"ignore_files"`
 	SuccessExitMessage *string      `yaml:"success_exit_message"`
-	AddNoteToMessage   bool         `yaml:"add_note_to_message"`
+	IncludeNote        bool         `yaml:"include_note"`
 }
 
 // NewConfig returns a new Config
@@ -68,7 +68,7 @@ func (c *Config) inExistingRules(r *rule.Rule) bool {
 
 // ConfigureRules adds the config Rules to DefaultRules
 // Configure RegExps for all rules
-// Configure AddNoteToMessage for all rules
+// Configure IncludeNote for all rules
 func (c *Config) ConfigureRules() {
 	for _, r := range rule.DefaultRules {
 		if !c.inExistingRules(r) {
@@ -78,7 +78,7 @@ func (c *Config) ConfigureRules() {
 
 	for _, r := range c.Rules {
 		r.SetRegexp()
-		r.SetAddNoteToMessage(c.AddNoteToMessage)
+		r.SetIncludeNote(c.IncludeNote)
 	}
 }
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -17,6 +17,7 @@ type Config struct {
 	Rules              []*rule.Rule `yaml:"rules"`
 	IgnoreFiles        []string     `yaml:"ignore_files"`
 	SuccessExitMessage *string      `yaml:"success_exit_message"`
+	AddNoteToMessage   bool         `yaml:"add_note_to_message"`
 }
 
 // NewConfig returns a new Config
@@ -66,6 +67,8 @@ func (c *Config) inExistingRules(r *rule.Rule) bool {
 }
 
 // ConfigureRules adds the config Rules to DefaultRules
+// Configure RegExps for all rules
+// Configure AddNoteToMessage for all rules
 func (c *Config) ConfigureRules() {
 	for _, r := range rule.DefaultRules {
 		if !c.inExistingRules(r) {
@@ -75,6 +78,7 @@ func (c *Config) ConfigureRules() {
 
 	for _, r := range c.Rules {
 		r.SetRegexp()
+		r.SetAddNoteToMessage(c.AddNoteToMessage)
 	}
 }
 

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -105,6 +105,36 @@ func TestNewConfig(t *testing.T) {
 		// check default config message
 		assert.Equal(t, "this is a test", c.GetSuccessExitMessage())
 	})
+
+	t.Run("config-add-note-messaage", func(t *testing.T) {
+		// Test when it is configured to add a note to the output message
+		c, err := NewConfig("testdata/add-note-message.yaml")
+		assert.NoError(t, err)
+
+		// check global AddNoteToMessage
+		assert.Equal(t, true, c.AddNoteToMessage)
+
+		// check AddNoteToMessage is set for rule2
+		assert.Equal(t, true, *c.Rules[1].Options.AddNoteToMessage)
+
+		// check AddNoteToMessage is not overridden for rule1
+		assert.Equal(t, false, *c.Rules[0].Options.AddNoteToMessage)
+	})
+
+	t.Run("config-dont-add-note-messaage", func(t *testing.T) {
+		// Test when it is nott configured to add a note to the output message
+		c, err := NewConfig("testdata/dont-add-note-message.yaml")
+		assert.NoError(t, err)
+
+		// check global AddNoteToMessage
+		assert.Equal(t, false, c.AddNoteToMessage)
+
+		// check AddNoteToMessage is not set for rule2
+		assert.Equal(t, false, *c.Rules[1].Options.AddNoteToMessage)
+
+		// check AddNoteToMessage is not overridden for rule1
+		assert.Equal(t, true, *c.Rules[0].Options.AddNoteToMessage)
+	})
 }
 
 func Test_relative(t *testing.T) {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -111,14 +111,14 @@ func TestNewConfig(t *testing.T) {
 		c, err := NewConfig("testdata/add-note-message.yaml")
 		assert.NoError(t, err)
 
-		// check global AddNoteToMessage
-		assert.Equal(t, true, c.AddNoteToMessage)
+		// check global IncludeNote
+		assert.Equal(t, true, c.IncludeNote)
 
-		// check AddNoteToMessage is set for rule2
-		assert.Equal(t, true, *c.Rules[1].Options.AddNoteToMessage)
+		// check IncludeNote is set for rule2
+		assert.Equal(t, true, *c.Rules[1].Options.IncludeNote)
 
-		// check AddNoteToMessage is not overridden for rule1
-		assert.Equal(t, false, *c.Rules[0].Options.AddNoteToMessage)
+		// check IncludeNote is not overridden for rule1
+		assert.Equal(t, false, *c.Rules[0].Options.IncludeNote)
 	})
 
 	t.Run("config-dont-add-note-messaage", func(t *testing.T) {
@@ -126,14 +126,14 @@ func TestNewConfig(t *testing.T) {
 		c, err := NewConfig("testdata/dont-add-note-message.yaml")
 		assert.NoError(t, err)
 
-		// check global AddNoteToMessage
-		assert.Equal(t, false, c.AddNoteToMessage)
+		// check global IncludeNote
+		assert.Equal(t, false, c.IncludeNote)
 
-		// check AddNoteToMessage is not set for rule2
-		assert.Equal(t, false, *c.Rules[1].Options.AddNoteToMessage)
+		// check IncludeNote is not set for rule2
+		assert.Equal(t, false, *c.Rules[1].Options.IncludeNote)
 
-		// check AddNoteToMessage is not overridden for rule1
-		assert.Equal(t, true, *c.Rules[0].Options.AddNoteToMessage)
+		// check IncludeNote is not overridden for rule1
+		assert.Equal(t, true, *c.Rules[0].Options.IncludeNote)
 	})
 }
 

--- a/pkg/config/testdata/add-note-message.yaml
+++ b/pkg/config/testdata/add-note-message.yaml
@@ -1,0 +1,20 @@
+rules:
+  - name: rule1
+    terms:
+      - rule1
+    alternatives:
+      - alt-rule1
+    severity: warning
+    options:
+      add_note_to_message: false
+  - name: rule2
+    terms:
+      - rule2
+    alternatives:
+      - alt-rule2
+    severity: warning
+
+
+
+success_exit_message: this is a test
+add_note_to_message: true

--- a/pkg/config/testdata/add-note-message.yaml
+++ b/pkg/config/testdata/add-note-message.yaml
@@ -6,7 +6,7 @@ rules:
       - alt-rule1
     severity: warning
     options:
-      add_note_to_message: false
+      include_note: false
   - name: rule2
     terms:
       - rule2
@@ -17,4 +17,4 @@ rules:
 
 
 success_exit_message: this is a test
-add_note_to_message: true
+include_note: true

--- a/pkg/config/testdata/dont-add-note-message.yaml
+++ b/pkg/config/testdata/dont-add-note-message.yaml
@@ -6,7 +6,7 @@ rules:
       - alt-rule1
     severity: warning
     options:
-      add_note_to_message: true
+      include_note: true
   - name: rule2
     terms:
       - rule2

--- a/pkg/config/testdata/dont-add-note-message.yaml
+++ b/pkg/config/testdata/dont-add-note-message.yaml
@@ -1,0 +1,19 @@
+rules:
+  - name: rule1
+    terms:
+      - rule1
+    alternatives:
+      - alt-rule1
+    severity: warning
+    options:
+      add_note_to_message: true
+  - name: rule2
+    terms:
+      - rule2
+    alternatives:
+      - alt-rule2
+    severity: warning
+
+
+
+success_exit_message: this is a test

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -186,12 +186,25 @@ func parsePathTests(t *testing.T) {
 		assert.NoError(t, err)
 	})
 
-	t.Run("note in output message", func(t *testing.T) {
+	t.Run("note is not included in output message", func(t *testing.T) {
+		const TestNote = "TEST NOTE"
+		p := testParser()
+		p.Rules[0].Note = TestNote
+		p.Rules[0].Options.IncludeNote = nil
+		pr := new(testPrinter)
+		p.ParsePaths(pr)
+
+		assert.NotContains(t, pr.results[0].Results[0].Reason(), TestNote)
+	})
+
+	t.Run("note is included in output message", func(t *testing.T) {
 		const TestNote = "TEST NOTE"
 		includeNote := true
 		p := testParser()
 		p.Rules[0].Note = TestNote
 		p.Rules[0].Options.IncludeNote = &includeNote
+		// Test IncludeNote flag doesn't get overridden with SetIncludeNote method
+		p.Rules[0].SetIncludeNote(false)
 		pr := new(testPrinter)
 		p.ParsePaths(pr)
 

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -185,6 +185,18 @@ func parsePathTests(t *testing.T) {
 		})
 		assert.NoError(t, err)
 	})
+
+	t.Run("note in output message", func(t *testing.T) {
+		const TestNote = "TEST NOTE"
+		addNoteToMessage := true
+		p := testParser()
+		p.Rules[0].Note = TestNote
+		p.Rules[0].Options.AddNoteToMessage = &addNoteToMessage
+		pr := new(testPrinter)
+		p.ParsePaths(pr)
+
+		assert.Contains(t, pr.results[0].Results[0].Reason(), TestNote)
+	})
 }
 
 func TestParser_ParsePaths(t *testing.T) {

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -188,10 +188,10 @@ func parsePathTests(t *testing.T) {
 
 	t.Run("note in output message", func(t *testing.T) {
 		const TestNote = "TEST NOTE"
-		addNoteToMessage := true
+		includeNote := true
 		p := testParser()
 		p.Rules[0].Note = TestNote
-		p.Rules[0].Options.AddNoteToMessage = &addNoteToMessage
+		p.Rules[0].Options.IncludeNote = &includeNote
 		pr := new(testPrinter)
 		p.ParsePaths(pr)
 

--- a/pkg/printer/json_test.go
+++ b/pkg/printer/json_test.go
@@ -14,6 +14,6 @@ func TestJSON_Print(t *testing.T) {
 	assert.NoError(t, p.Print(buf, res))
 	got := buf.String()
 
-	expected := `{"Filename":"foo.txt","Results":[{"Rule":{"Name":"whitelist","Terms":["whitelist","white-list","whitelisted","white-listed"],"Alternatives":["allowlist"],"Note":"","Severity":"warning","Options":{"WordBoundary":false,"AddNoteToMessage":null}},"Violation":"whitelist","Line":"this whitelist must change","StartPosition":{"Filename":"foo.txt","Offset":0,"Line":1,"Column":6},"EndPosition":{"Filename":"foo.txt","Offset":0,"Line":1,"Column":15},"Reason":"` + "`whitelist`" + ` may be insensitive, use ` + "`allowlist`" + ` instead"}]}` + "\n"
+	expected := `{"Filename":"foo.txt","Results":[{"Rule":{"Name":"whitelist","Terms":["whitelist","white-list","whitelisted","white-listed"],"Alternatives":["allowlist"],"Note":"","Severity":"warning","Options":{"WordBoundary":false,"IncludeNote":null}},"Violation":"whitelist","Line":"this whitelist must change","StartPosition":{"Filename":"foo.txt","Offset":0,"Line":1,"Column":6},"EndPosition":{"Filename":"foo.txt","Offset":0,"Line":1,"Column":15},"Reason":"` + "`whitelist`" + ` may be insensitive, use ` + "`allowlist`" + ` instead"}]}` + "\n"
 	assert.Equal(t, expected, got)
 }

--- a/pkg/printer/json_test.go
+++ b/pkg/printer/json_test.go
@@ -14,6 +14,6 @@ func TestJSON_Print(t *testing.T) {
 	assert.NoError(t, p.Print(buf, res))
 	got := buf.String()
 
-	expected := `{"Filename":"foo.txt","Results":[{"Rule":{"Name":"whitelist","Terms":["whitelist","white-list","whitelisted","white-listed"],"Alternatives":["allowlist"],"Note":"","Severity":"warning","Options":{"WordBoundary":false}},"Violation":"whitelist","Line":"this whitelist must change","StartPosition":{"Filename":"foo.txt","Offset":0,"Line":1,"Column":6},"EndPosition":{"Filename":"foo.txt","Offset":0,"Line":1,"Column":15},"Reason":"` + "`whitelist`" + ` may be insensitive, use ` + "`allowlist`" + ` instead"}]}` + "\n"
+	expected := `{"Filename":"foo.txt","Results":[{"Rule":{"Name":"whitelist","Terms":["whitelist","white-list","whitelisted","white-listed"],"Alternatives":["allowlist"],"Note":"","Severity":"warning","Options":{"WordBoundary":false,"AddNoteToMessage":null}},"Violation":"whitelist","Line":"this whitelist must change","StartPosition":{"Filename":"foo.txt","Offset":0,"Line":1,"Column":6},"EndPosition":{"Filename":"foo.txt","Offset":0,"Line":1,"Column":15},"Reason":"` + "`whitelist`" + ` may be insensitive, use ` + "`allowlist`" + ` instead"}]}` + "\n"
 	assert.Equal(t, expected, got)
 }

--- a/pkg/result/lineresult.go
+++ b/pkg/result/lineresult.go
@@ -63,7 +63,7 @@ func FindResults(r *rule.Rule, filename, text string, line int) (rs []Result) {
 
 // Reason outputs the suggested alternatives for this rule
 func (r LineResult) Reason() string {
-	return r.Rule.Reason(r.Violation)
+	return r.Rule.ReasonWithNote(r.Violation)
 }
 
 func (r LineResult) String() string {

--- a/pkg/result/pathresult.go
+++ b/pkg/result/pathresult.go
@@ -16,7 +16,7 @@ type PathResult struct {
 // It is similar to Result.Reason, but makes it clear that the violation is
 // with the file path and not a line in the file
 func (r PathResult) Reason() string {
-	return "Filename violation: " + r.Rule.Reason(r.LineResult.Violation)
+	return "Filename violation: " + r.Rule.ReasonWithNote(r.LineResult.Violation)
 }
 
 // MatchPathRules will match the path against all the rules provided

--- a/pkg/rule/default.yaml
+++ b/pkg/rule/default.yaml
@@ -10,6 +10,7 @@
     - allowlist
     - inclusion list
   severity: warning
+  note: "The underlying assumption of the whitelist/blacklist metaphor is that white = good and black = bad. Because colors in and of themselves have no predetermined meaning, any meaning we assign to them is cultural: for example, the color red in many Southeast Asian countries is lucky, and is often associated with events like marriages, whereas the color white carries the same connotations in many European countries. In the case of whitelist/blacklist, the terms originate in the publishing industry – one dominated by the USA and England, two countries which participated in slavery and which grapple with their racist legacies to this day."
 
 - name: blacklist
   terms:
@@ -22,6 +23,7 @@
     - blocklist
     - exclusion list
   severity: warning
+  note: "The underlying assumption of the whitelist/blacklist metaphor is that white = good and black = bad. Because colors in and of themselves have no predetermined meaning, any meaning we assign to them is cultural: for example, the color red in many Southeast Asian countries is lucky, and is often associated with events like marriages, whereas the color white carries the same connotations in many European countries. In the case of whitelist/blacklist, the terms originate in the publishing industry – one dominated by the USA and England, two countries which participated in slavery and which grapple with their racist legacies to this day."
 
 - name: master-slave
   terms:

--- a/pkg/rule/options.go
+++ b/pkg/rule/options.go
@@ -2,5 +2,6 @@ package rule
 
 // Options are options that can be configured and applied on a per-rule basis
 type Options struct {
-	WordBoundary bool `yaml:"word_boundary"`
+	WordBoundary     bool  `yaml:"word_boundary"`
+	AddNoteToMessage *bool `yaml:"add_note_to_message"`
 }

--- a/pkg/rule/options.go
+++ b/pkg/rule/options.go
@@ -2,6 +2,6 @@ package rule
 
 // Options are options that can be configured and applied on a per-rule basis
 type Options struct {
-	WordBoundary     bool  `yaml:"word_boundary"`
-	AddNoteToMessage *bool `yaml:"add_note_to_message"`
+	WordBoundary bool  `yaml:"word_boundary"`
+	IncludeNote  *bool `yaml:"include_note"`
 }

--- a/pkg/rule/rule.go
+++ b/pkg/rule/rule.go
@@ -122,9 +122,9 @@ func (r *Rule) Reason(violation string) string {
 	return reason.String()
 }
 
-func (r *Rule) addNoteToMessage() bool {
-	if r.Options.AddNoteToMessage != nil {
-		return *r.Options.AddNoteToMessage
+func (r *Rule) includeNote() bool {
+	if r.Options.IncludeNote != nil {
+		return *r.Options.IncludeNote
 	}
 	return false
 }
@@ -132,7 +132,7 @@ func (r *Rule) addNoteToMessage() bool {
 // ReasonWithNote returns a human-readable reason for the rule violation
 // with an additional note, if defined.
 func (r *Rule) ReasonWithNote(violation string) string {
-	if len(r.Note) == 0 || !r.addNoteToMessage() {
+	if len(r.Note) == 0 || !r.includeNote() {
 		return r.Reason(violation)
 	}
 	return fmt.Sprintf("%s (%s)", r.Reason(violation), r.Note)
@@ -199,13 +199,13 @@ func (r *Rule) Disabled() bool {
 	return len(r.Terms) == 0
 }
 
-// SetAddNoteToMessage populates AddNoteToMessage attributte in Options
-// Options.AddNoteToMessage is ussed in ReasonWithNote
-// If "add_note_to_message" is already defined for the rule in yaml, it will not be overridden
-func (r *Rule) SetAddNoteToMessage(addNoteToMessage bool) {
-	if r.Options.AddNoteToMessage != nil {
+// SetIncludeNote populates IncludeNote attributte in Options
+// Options.IncludeNote is ussed in ReasonWithNote
+// If "include_note" is already defined for the rule in yaml, it will not be overridden
+func (r *Rule) SetIncludeNote(includeNote bool) {
+	if r.Options.IncludeNote != nil {
 		return
 	}
 
-	r.Options.AddNoteToMessage = &addNoteToMessage
+	r.Options.IncludeNote = &includeNote
 }

--- a/pkg/rule/rule.go
+++ b/pkg/rule/rule.go
@@ -122,10 +122,17 @@ func (r *Rule) Reason(violation string) string {
 	return reason.String()
 }
 
+func (r *Rule) addNoteToMessage() bool {
+	if r.Options.AddNoteToMessage != nil {
+		return *r.Options.AddNoteToMessage
+	}
+	return false
+}
+
 // ReasonWithNote returns a human-readable reason for the rule violation
 // with an additional note, if defined.
 func (r *Rule) ReasonWithNote(violation string) string {
-	if len(r.Note) == 0 {
+	if len(r.Note) == 0 || !r.addNoteToMessage() {
 		return r.Reason(violation)
 	}
 	return fmt.Sprintf("%s (%s)", r.Reason(violation), r.Note)
@@ -190,4 +197,15 @@ func removeInlineIgnore(line string) string {
 // way to disable a default rule, and then, if a rule has no Terms, it falls back to the Name.
 func (r *Rule) Disabled() bool {
 	return len(r.Terms) == 0
+}
+
+// SetAddNoteToMessage populates AddNoteToMessage attributte in Options
+// Options.AddNoteToMessage is ussed in ReasonWithNote
+// If "add_note_to_message" is already defined for the rule in yaml, it will not be overridden
+func (r *Rule) SetAddNoteToMessage(addNoteToMessage bool) {
+	if r.Options.AddNoteToMessage != nil {
+		return
+	}
+
+	r.Options.AddNoteToMessage = &addNoteToMessage
 }

--- a/pkg/rule/rule_test.go
+++ b/pkg/rule/rule_test.go
@@ -155,3 +155,15 @@ func Test_removeInlineIgnore(t *testing.T) {
 		})
 	}
 }
+
+func TestRule_IncludeNote(t *testing.T) {
+	r := testRule()
+	includeNote := true
+
+	assert.Equal(t, false, r.includeNote())
+
+	// Test IncludeNote flag doesn't get overridden with SetIncludeNote method
+	r.Options.IncludeNote = &includeNote
+	r.SetIncludeNote(false)
+	assert.Equal(t, true, r.includeNote())
+}

--- a/pkg/rule/rule_test.go
+++ b/pkg/rule/rule_test.go
@@ -49,6 +49,7 @@ func TestRule_ReasonWithNote(t *testing.T) {
 	assert.Equal(t, "`rule-1` may be insensitive, use `alt-rule1`, `alt-rule-1` instead", r.ReasonWithNote("rule-1"))
 
 	r.Note = "rule note here"
+	r.SetAddNoteToMessage(true)
 	assert.Equal(t, "`rule-1` may be insensitive, use `alt-rule1`, `alt-rule-1` instead (rule note here)", r.ReasonWithNote("rule-1"))
 }
 

--- a/pkg/rule/rule_test.go
+++ b/pkg/rule/rule_test.go
@@ -49,7 +49,7 @@ func TestRule_ReasonWithNote(t *testing.T) {
 	assert.Equal(t, "`rule-1` may be insensitive, use `alt-rule1`, `alt-rule-1` instead", r.ReasonWithNote("rule-1"))
 
 	r.Note = "rule note here"
-	r.SetAddNoteToMessage(true)
+	r.SetIncludeNote(true)
 	assert.Equal(t, "`rule-1` may be insensitive, use `alt-rule1`, `alt-rule-1` instead (rule note here)", r.ReasonWithNote("rule-1"))
 }
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The commit message follows our [guidelines](https://github.com/get-woke/woke/blob/main/CONTRIBUTING.md)
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
The rule definition has "Note" attribute which is supposed to contain explanation why the rule terms are concidered not inclusive. It would be beneficial for education purposes if the linter could (optionally) provide in its output not only suggestions with alternatives, but the reason/explanation as well. So the author could understand why they should care about this violation.


**What is the current behavior?** (You can also link to an open issue here)
Currently the "Note" is not shown anywhere. There is a method [ReasonWithNote](https://github.com/get-woke/woke/blob/2e9f79d1cf8c8eaf71a776af613ffd537d083de2/pkg/rule/rule.go#L127) which is supposed to provide the desired behavior, but it's not used.


**What is the new behavior (if this is a feature change)?**
- **.woke.yaml** configuration file may contain **add_note_to_message (bool)** attribute, so if it's true (false by default) the output message will contain the Note for all rules unless it's specified otherwise explicitly at the rule level  
- The rule definition **Options** may contain **add_note_to_message (bool)** attribute, which dictates if the Note should be included in the output message for this specific rule.

**Does this PR introduce a breaking change?** (What changes might users need to make due to this PR?)
No

**Other information**:
