### PR TITLE
Bug fix: check names of ALL files

### DIFF
--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -135,11 +135,6 @@ func (p *Parser) walkDir(dirname string, done chan bool) <-chan string {
 				return nil
 			}
 
-			if err := util.IsTextFileFromFilename(path); err != nil {
-				log.Debug().Str("file", path).Str("reason", err.Error()).Msg("skipping")
-				return nil
-			}
-
 			paths <- path
 			return nil
 		})

--- a/pkg/parser/violations.go
+++ b/pkg/parser/violations.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/get-woke/woke/pkg/result"
+	"github.com/get-woke/woke/pkg/util"
 
 	"github.com/rs/zerolog/log"
 )
@@ -41,6 +42,12 @@ func (p *Parser) generateFileViolations(file *os.File) (*result.FileResults, err
 	// Check for violations in the filename itself
 	for _, pathResult := range result.MatchPathRules(p.Rules, file.Name()) {
 		results.Results = append(results.Results, pathResult)
+	}
+
+	// Don't check file content if it's not a text file or file is empty
+	if err := util.IsTextFileFromFilename(filename); err != nil {
+		log.Debug().Str("file", filename).Str("reason", err.Error()).Msg("skipping content")
+		return results, nil
 	}
 
 	reader := bufio.NewReader(file)

--- a/pkg/parser/violations_test.go
+++ b/pkg/parser/violations_test.go
@@ -75,6 +75,17 @@ func TestGenerateFileViolations(t *testing.T) {
 		assert.Len(t, res.Results, 1)
 		assert.Regexp(t, "^Filename violation: ", res.Results[0].Reason())
 	})
+
+	t.Run("filename violation for empty file", func(t *testing.T) {
+		f, err := newFileWithPrefix(t, "empty-whitelist-", "")
+		assert.NoError(t, err)
+
+		p := testParser()
+		res, err := p.generateFileViolationsFromFilename(f.Name())
+		assert.NoError(t, err)
+		assert.Len(t, res.Results, 1)
+		assert.Regexp(t, "^Filename violation: ", res.Results[0].Reason())
+	})
 }
 
 // newFile creates a new file for testing. The file, and the directory that the file


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The commit message follows our [guidelines](https://github.com/get-woke/woke/blob/main/CONTRIBUTING.md)
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Check file names of all files in the target path.


**What is the current behavior?** (You can also link to an open issue here)
Currently names of empty files and just non-text files are not analyzed. 


**What is the new behavior (if this is a feature change)?**
Analyze names of all files in the target path, but still skip analyzing content of empty files and non-text files.


**Does this PR introduce a breaking change?** (What changes might users need to make due to this PR?)
The linter may detect more violations as all file names are analyzed. If, for some reason, names of some files should not be analyzed, they should be added to the ignore list. 

**Other information**:
