### PR TITLE
Bug: fix running stdin 

### DIFF
--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -27,7 +27,8 @@ func (p *testPrinter) Print(_ io.Writer, r *result.FileResults) error {
 }
 
 func testParser() *Parser {
-	return NewParser([]*rule.Rule{&rule.TestRule}, ignore.NewIgnore([]string{}))
+	r := rule.TestRule
+	return NewParser([]*rule.Rule{&r}, ignore.NewIgnore([]string{}))
 }
 
 func parsePathTests(t *testing.T) {

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -78,6 +78,18 @@ func parsePathTests(t *testing.T) {
 		assert.Len(t, pr.results, 0)
 		assert.Equal(t, len(pr.results), violations)
 	})
+
+	t.Run("violation in filename - empty file", func(t *testing.T) {
+		f, err := newFileWithPrefix(t, "whitelist", "")
+		assert.NoError(t, err)
+
+		p := testParser()
+		pr := new(testPrinter)
+		violations := p.ParsePaths(pr, f.Name())
+		assert.Len(t, pr.results, 1)
+		assert.Equal(t, len(pr.results), violations)
+	})
+
 	t.Run("IsTextFileFromFilename failure", func(t *testing.T) {
 		f, err := newFile(t, "")
 		assert.NoError(t, err)

--- a/pkg/util/contenttype.go
+++ b/pkg/util/contenttype.go
@@ -33,6 +33,11 @@ func isTextFile(file *os.File) bool {
 
 // IsTextFileFromFilename returns an error if the filename is not of content-type 'text/*'
 func IsTextFileFromFilename(filename string) error {
+	// Don't check stdin to avoid closing it prematurely
+	if filename == os.Stdin.Name() {
+		return nil
+	}
+
 	f, err := os.Open(filename)
 	if err != nil {
 		return err

--- a/pkg/util/contenttype_test.go
+++ b/pkg/util/contenttype_test.go
@@ -93,4 +93,9 @@ func TestIsTextFileFromFilename(t *testing.T) {
 		err := IsTextFileFromFilename("testdata")
 		assert.EqualError(t, err, ErrIsDir.Error())
 	})
+
+	t.Run("stdin", func(t *testing.T) {
+		err := IsTextFileFromFilename(os.Stdin.Name())
+		assert.NoError(t, err)
+	})
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The commit message follows our [guidelines](https://github.com/get-woke/woke/blob/main/CONTRIBUTING.md)
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix for stdin, which stopped working on v0.8.1.


**What is the current behavior?** (You can also link to an open issue here)
#85 


**What is the new behavior (if this is a feature change)?**
Previous behavior:

```bash
$ echo "whitelist" | go run main.go --stdin
No violations found. Stay woke ✊
```

New behavior:

```bash
$ echo "whitelist" | go run main.go --stdin
/dev/stdin:1:0-9: `whitelist` may be insensitive, use `allowlist`, `inclusion list` instead (warning)
whitelist
^
```


**Does this PR introduce a breaking change?** (What changes might users need to make due to this PR?)
No

**Other information**:

stdin stopped working in v0.8.1, related to changes in #78 which checked if the file is a text file in a different place. It was causing `IsTextFileFromFilename` to open stdin, which it saw as an empty file and would ignore it.