### PR TITLE
Fixed word boundary tests on paths

### DIFF
--- a/pkg/result/pathresult.go
+++ b/pkg/result/pathresult.go
@@ -36,7 +36,7 @@ func MatchPath(r *rule.Rule, path string) (rs []PathResult) {
 
 	for _, p := range dirParts {
 		p = filepath.ToSlash(p)
-		if r.MatchString(p, false) {
+		if len(r.FindMatchIndexes(p)) > 0 {
 			rs = append(rs, PathResult{LineResult: NewLineResult(r, p, path, 1, 1, 1)})
 		}
 	}

--- a/pkg/result/pathresult_test.go
+++ b/pkg/result/pathresult_test.go
@@ -29,3 +29,33 @@ func TestMatchPathRules(t *testing.T) {
 		})
 	}
 }
+
+func TestMatchPathRulesBoundary(t *testing.T) {
+	tt := []struct {
+		path    string
+		matches int
+	}{
+		{path: "/whitelist/list/test.go", matches: 1},
+		{path: "/testwhitelist/list/test.go", matches: 0},
+		{path: "/whitetest/list/test.go", matches: 0},
+		{path: "/whitelist.test/list/test.go", matches: 1},
+		{path: "/whitelist.test/blacklist/test.go", matches: 2},
+		{path: "/whitelisttest/blacklist/test.go", matches: 1},
+		{path: "/foo/bar/path_test.go", matches: 0},
+		{path: "/foo/bar/whitelistblacklist-new.go", matches: 0},
+		{path: "/foo/bar/whitelist-new.go", matches: 1},
+	}
+	for _, test := range tt {
+		t.Run(test.path, func(t *testing.T) {
+			defaultRules := rule.DefaultRules
+			for i := range defaultRules {
+				defaultRules[i].Options.WordBoundary = true
+			}
+			pr := MatchPathRules(defaultRules, test.path)
+			assert.Len(t, pr, test.matches)
+			for _, p := range pr {
+				assert.Equal(t, "Filename violation: "+p.Rule.Reason(p.LineResult.Violation), p.Reason())
+			}
+		})
+	}
+}


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [ X ] The commit message follows our [guidelines](https://github.com/get-woke/woke/blob/main/CONTRIBUTING.md)
- [ X ] Tests for the changes have been added (for bug fixes / features)
- [ N/A ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix


**What is the current behavior?** (You can also link to an open issue here)
Currently, the boundary option is not respected when testing file paths. This is due to a difference between the matching code used for testing normal text and paths.


**What is the new behavior (if this is a feature change)?**
Changed the functionality to respect word boundaries, matching the functionality of line tests.


**Does this PR introduce a breaking change?** (What changes might users need to make due to this PR?)
Only if a consumer of the tool expects files name matching and content matching to differ for word boundaries, probably unlikely.

**Other information**:
N/A

Fixes #94 