### PR TITLE
dev: Replace term `violations` with `findings`

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,10 +229,10 @@ You can configure options for each rule. Add an `options` key to your rule defin
 Current options include:
 
 - `word_boundary` (default: `false`)
-  - If `true`, terms will trigger violations when they are surrounded by ASCII word boundaries.
-  - If `false`, will trigger violations if the term if found anywhere in the line, regardless if it is within an ASCII word boundary.
+  - If `true`, terms will trigger findings when they are surrounded by ASCII word boundaries.
+  - If `false`, will trigger findings if the term if found anywhere in the line, regardless if it is within an ASCII word boundary.
 - `include_note` (default: `not set`)
-  - If `true`, the rule note will be included in the output message explaining why this violation is not inclusive
+  - If `true`, the rule note will be included in the output message explaining why this finding is not inclusive
   - If `false`, the rule note will not be included in the output message
   - If `not set`, `include_note` in your `woke` config file (ie `.woke.yml`) regulates if the note should be included in the output message (default: `false`).
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -103,15 +103,15 @@ func rootRunE(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	violations := p.ParsePaths(print, parseArgs(args)...)
+	findings := p.ParsePaths(print, parseArgs(args)...)
 
-	if exitOneOnFailure && violations > 0 {
+	if exitOneOnFailure && findings > 0 {
 		// We intentionally return an error if exitOneOnFailure is true, but don't want to show usage
 		cmd.SilenceUsage = true
-		err = fmt.Errorf("files with violations: %d", violations)
+		err = fmt.Errorf("files with findings: %d", findings)
 	}
 
-	if violations == 0 {
+	if findings == 0 {
 		if cfg.GetSuccessExitMessage() != "" {
 			fmt.Fprintln(output.Stdout, cfg.GetSuccessExitMessage())
 		}

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -66,7 +66,7 @@ func TestRunE(t *testing.T) {
 		viper.SetConfigName(origConfigFile)
 	})
 
-	t.Run("no violations found", func(t *testing.T) {
+	t.Run("no findings found", func(t *testing.T) {
 		buf := new(bytes.Buffer)
 		output.Stdout = buf
 
@@ -74,11 +74,11 @@ func TestRunE(t *testing.T) {
 		assert.NoError(t, err)
 
 		got := buf.String()
-		expected := "No violations found. Stay woke \u270a\n"
+		expected := "No findings found. Stay woke \u270a\n"
 		assert.Equal(t, expected, got)
 	})
 
-	t.Run("no violations found with custom message", func(t *testing.T) {
+	t.Run("no findings found with custom message", func(t *testing.T) {
 		buf := new(bytes.Buffer)
 		output.Stdout = buf
 
@@ -91,11 +91,11 @@ func TestRunE(t *testing.T) {
 		assert.Equal(t, expected, got)
 	})
 
-	t.Run("violations w error", func(t *testing.T) {
+	t.Run("findings w error", func(t *testing.T) {
 		exitOneOnFailure = true
 
 		err := rootRunE(new(cobra.Command), []string{"../testdata"})
 		assert.Error(t, err)
-		assert.Regexp(t, regexp.MustCompile(`^files with violations: \d`), err.Error())
+		assert.Regexp(t, regexp.MustCompile(`^files with findings: \d`), err.Error())
 	})
 }

--- a/example.yaml
+++ b/example.yaml
@@ -22,4 +22,4 @@ rules:
 
 # optional if you want to have a custom success message
 # you can also set this to an empty string `""` to output no message at all
-# success_exit_message: No violations found
+# success_exit_message: No findings found

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -52,7 +52,7 @@ func NewConfig(filename string) (*Config, error) {
 
 func (c *Config) GetSuccessExitMessage() string {
 	if c.SuccessExitMessage == nil {
-		return "No violations found. Stay woke ✊"
+		return "No findings found. Stay woke ✊"
 	}
 	return *c.SuccessExitMessage
 }

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -66,7 +66,7 @@ func TestNewConfig(t *testing.T) {
 		assert.EqualValues(t, expected.Rules, c.Rules)
 
 		// check default config message
-		assert.Equal(t, "No violations found. Stay woke ✊", c.GetSuccessExitMessage())
+		assert.Equal(t, "No findings found. Stay woke ✊", c.GetSuccessExitMessage())
 	})
 
 	t.Run("config-empty-missing", func(t *testing.T) {

--- a/pkg/parser/findings.go
+++ b/pkg/parser/findings.go
@@ -14,32 +14,32 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
-func (p *Parser) generateFileViolationsFromFilename(filename string) (*result.FileResults, error) {
+func (p *Parser) generateFileFindingsFromFilename(filename string) (*result.FileResults, error) {
 	file, err := os.Open(filename)
 	if err != nil {
 		return nil, err
 	}
 	defer file.Close()
-	return p.generateFileViolations(file)
+	return p.generateFileFindings(file)
 }
 
-// generateFileViolations reads the file and returns results of places where rules are broken
+// generateFileFindings reads the file and returns results of places where rules are broken
 // this function will not close the file, that should be handled by the caller
-func (p *Parser) generateFileViolations(file *os.File) (*result.FileResults, error) {
+func (p *Parser) generateFileFindings(file *os.File) (*result.FileResults, error) {
 	filename := filepath.ToSlash(file.Name())
 	start := time.Now()
 	defer func() {
 		log.Debug().
 			TimeDiff("durationMS", time.Now(), start).
 			Str("file", filename).
-			Msg("finished processing violations")
+			Msg("finished processing findings")
 	}()
 
 	results := &result.FileResults{
 		Filename: filename,
 	}
 
-	// Check for violations in the filename itself
+	// Check for findings in the filename itself
 	for _, pathResult := range result.MatchPathRules(p.Rules, file.Name()) {
 		results.Results = append(results.Results, pathResult)
 	}

--- a/pkg/parser/findings_test.go
+++ b/pkg/parser/findings_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestGenerateFileViolations(t *testing.T) {
+func TestGenerateFileFindings(t *testing.T) {
 	tests := []struct {
 		desc    string
 		content string
@@ -31,7 +31,7 @@ func TestGenerateFileViolations(t *testing.T) {
 			f, err := newFile(t, tc.content)
 			assert.NoError(t, err)
 			p := testParser()
-			res, err := p.generateFileViolationsFromFilename(f.Name())
+			res, err := p.generateFileFindingsFromFilename(f.Name())
 			assert.NoError(t, err)
 
 			filename := filepath.ToSlash(f.Name())
@@ -40,9 +40,9 @@ func TestGenerateFileViolations(t *testing.T) {
 				Results:  make([]result.Result, 1),
 			}
 			expected.Results[0] = result.LineResult{
-				Rule:      &rule.TestRule,
-				Violation: "whitelist",
-				Line:      tc.line,
+				Rule:    &rule.TestRule,
+				Finding: "whitelist",
+				Line:    tc.line,
 				StartPosition: &token.Position{
 					Filename: filename,
 					Offset:   0,
@@ -61,30 +61,30 @@ func TestGenerateFileViolations(t *testing.T) {
 	}
 	t.Run("missing file", func(t *testing.T) {
 		p := testParser()
-		_, err := p.generateFileViolationsFromFilename("missing.file")
+		_, err := p.generateFileFindingsFromFilename("missing.file")
 		assert.Error(t, err)
 	})
 
-	t.Run("filename violation", func(t *testing.T) {
+	t.Run("filename finding", func(t *testing.T) {
 		f, err := newFileWithPrefix(t, "whitelist-", "content")
 		assert.NoError(t, err)
 
 		p := testParser()
-		res, err := p.generateFileViolationsFromFilename(f.Name())
+		res, err := p.generateFileFindingsFromFilename(f.Name())
 		assert.NoError(t, err)
 		assert.Len(t, res.Results, 1)
-		assert.Regexp(t, "^Filename violation: ", res.Results[0].Reason())
+		assert.Regexp(t, "^Filename finding: ", res.Results[0].Reason())
 	})
 
-	t.Run("filename violation for empty file", func(t *testing.T) {
+	t.Run("filename finding for empty file", func(t *testing.T) {
 		f, err := newFileWithPrefix(t, "empty-whitelist-", "")
 		assert.NoError(t, err)
 
 		p := testParser()
-		res, err := p.generateFileViolationsFromFilename(f.Name())
+		res, err := p.generateFileFindingsFromFilename(f.Name())
 		assert.NoError(t, err)
 		assert.Len(t, res.Results, 1)
-		assert.Regexp(t, "^Filename violation: ", res.Results[0].Reason())
+		assert.Regexp(t, "^Filename finding: ", res.Results[0].Reason())
 	})
 }
 
@@ -112,7 +112,7 @@ func newFileWithPrefix(t *testing.T, prefix, text string) (*os.File, error) {
 }
 
 // Tests for when a rule name is used with inline wokeignore, when that rule name matches another rule
-func TestGenerateFileViolationsOverlappingRules(t *testing.T) {
+func TestGenerateFileFindingsOverlappingRules(t *testing.T) {
 	tests := []struct {
 		desc    string
 		content string
@@ -128,7 +128,7 @@ func TestGenerateFileViolationsOverlappingRules(t *testing.T) {
 			assert.NoError(t, err)
 
 			p := testParser()
-			res, err := p.generateFileViolationsFromFilename(f.Name())
+			res, err := p.generateFileFindingsFromFilename(f.Name())
 			assert.NoError(t, err)
 			assert.Len(t, res.Results, tc.matches)
 		})

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -32,24 +32,24 @@ func testParser() *Parser {
 }
 
 func parsePathTests(t *testing.T) {
-	t.Run("violation", func(t *testing.T) {
+	t.Run("finding", func(t *testing.T) {
 		f, err := newFile(t, "i have a whitelist")
 		assert.NoError(t, err)
 
 		pr := new(testPrinter)
 		p := testParser()
-		violations := p.ParsePaths(pr, f.Name())
+		findings := p.ParsePaths(pr, f.Name())
 		assert.Len(t, pr.results, 1)
-		assert.Equal(t, len(pr.results), violations)
+		assert.Equal(t, len(pr.results), findings)
 
 		filename := filepath.ToSlash(f.Name())
 		expected := result.FileResults{
 			Filename: filename,
 			Results: []result.Result{
 				result.LineResult{
-					Rule:      &rule.TestRule,
-					Violation: "whitelist",
-					Line:      "i have a whitelist",
+					Rule:    &rule.TestRule,
+					Finding: "whitelist",
+					Line:    "i have a whitelist",
 					StartPosition: &token.Position{
 						Filename: filename,
 						Offset:   0,
@@ -68,26 +68,26 @@ func parsePathTests(t *testing.T) {
 		assert.EqualValues(t, &expected, pr.results[0])
 	})
 
-	t.Run("no violations", func(t *testing.T) {
-		f, err := newFile(t, "i have a no violations\n")
+	t.Run("no findings", func(t *testing.T) {
+		f, err := newFile(t, "i have a no findings\n")
 		assert.NoError(t, err)
 
 		p := testParser()
 		pr := new(testPrinter)
-		violations := p.ParsePaths(pr, f.Name())
+		findings := p.ParsePaths(pr, f.Name())
 		assert.Len(t, pr.results, 0)
-		assert.Equal(t, len(pr.results), violations)
+		assert.Equal(t, len(pr.results), findings)
 	})
 
-	t.Run("violation in filename - empty file", func(t *testing.T) {
+	t.Run("finding in filename - empty file", func(t *testing.T) {
 		f, err := newFileWithPrefix(t, "whitelist", "")
 		assert.NoError(t, err)
 
 		p := testParser()
 		pr := new(testPrinter)
-		violations := p.ParsePaths(pr, f.Name())
+		findings := p.ParsePaths(pr, f.Name())
 		assert.Len(t, pr.results, 1)
-		assert.Equal(t, len(pr.results), violations)
+		assert.Equal(t, len(pr.results), findings)
 	})
 
 	t.Run("IsTextFileFromFilename failure", func(t *testing.T) {
@@ -96,70 +96,70 @@ func parsePathTests(t *testing.T) {
 
 		p := testParser()
 		pr := new(testPrinter)
-		violations := p.ParsePaths(pr, f.Name())
+		findings := p.ParsePaths(pr, f.Name())
 		assert.Len(t, pr.results, 0)
-		assert.Equal(t, len(pr.results), violations)
+		assert.Equal(t, len(pr.results), findings)
 	})
 
 	t.Run("multiple paths", func(t *testing.T) {
 		f1, err := newFile(t, "i have a whitelist\n")
 		assert.NoError(t, err)
-		f2, err := newFile(t, "i have a no violations\n")
+		f2, err := newFile(t, "i have a no findings\n")
 		assert.NoError(t, err)
 
 		// Test with multiple paths supplied
 		p := testParser()
 		pr := new(testPrinter)
-		violations := p.ParsePaths(pr, f1.Name(), f2.Name())
+		findings := p.ParsePaths(pr, f1.Name(), f2.Name())
 		assert.Len(t, pr.results, 1)
-		assert.Equal(t, len(pr.results), violations)
+		assert.Equal(t, len(pr.results), findings)
 	})
 
 	t.Run("ignored", func(t *testing.T) {
-		f, err := newFile(t, "i have a whitelist violation, but am ignored\n")
+		f, err := newFile(t, "i have a whitelist finding, but am ignored\n")
 		assert.NoError(t, err)
 
 		p := testParser()
 		p.Ignorer = ignore.NewIgnore([]string{filepath.ToSlash(f.Name())})
 		pr := new(testPrinter)
 
-		violations := p.ParsePaths(pr, f.Name())
+		findings := p.ParsePaths(pr, f.Name())
 		assert.Len(t, pr.results, 0)
-		assert.Equal(t, len(pr.results), violations)
+		assert.Equal(t, len(pr.results), findings)
 	})
 
 	t.Run("ignored inline", func(t *testing.T) {
-		f, err := newFile(t, "i have a whitelist violation, but am ignored # wokeignore:rule=whitelist\n")
+		f, err := newFile(t, "i have a whitelist finding, but am ignored # wokeignore:rule=whitelist\n")
 		assert.NoError(t, err)
 
 		p := testParser()
 		pr := new(testPrinter)
 
-		violations := p.ParsePaths(pr, f.Name())
+		findings := p.ParsePaths(pr, f.Name())
 		assert.Len(t, pr.results, 0)
-		assert.Equal(t, len(pr.results), violations)
+		assert.Equal(t, len(pr.results), findings)
 	})
 
 	t.Run("ignored inline with no ignorer", func(t *testing.T) {
-		f, err := newFile(t, "i have a whitelist violation, but am ignored # wokeignore:rule=whitelist\n")
+		f, err := newFile(t, "i have a whitelist finding, but am ignored # wokeignore:rule=whitelist\n")
 		assert.NoError(t, err)
 
 		p := testParser()
 		p.Ignorer = nil
 		pr := new(testPrinter)
 
-		violations := p.ParsePaths(pr, f.Name())
+		findings := p.ParsePaths(pr, f.Name())
 		assert.Len(t, pr.results, 1)
-		assert.Equal(t, len(pr.results), violations)
+		assert.Equal(t, len(pr.results), findings)
 	})
 
 	t.Run("default path", func(t *testing.T) {
 		// Test default path (which would run tests against the parser package)
 		p := testParser()
 		pr := new(testPrinter)
-		violations := p.ParsePaths(pr)
+		findings := p.ParsePaths(pr)
 
-		assert.Equal(t, len(pr.results), violations)
+		assert.Equal(t, len(pr.results), findings)
 		assert.Greater(t, len(pr.results), 0)
 	})
 
@@ -167,18 +167,18 @@ func parsePathTests(t *testing.T) {
 		err := writeToStdin(t, "i have a whitelist here\n", func() {
 			p := testParser()
 			pr := new(testPrinter)
-			violations := p.ParsePaths(pr, os.Stdin.Name())
+			findings := p.ParsePaths(pr, os.Stdin.Name())
 			assert.Len(t, pr.results, 1)
-			assert.Equal(t, len(pr.results), violations)
+			assert.Equal(t, len(pr.results), findings)
 
 			filename := filepath.ToSlash(os.Stdin.Name())
 			expected := result.FileResults{
 				Filename: filename,
 				Results: []result.Result{
 					result.LineResult{
-						Rule:      &rule.TestRule,
-						Violation: "whitelist",
-						Line:      "i have a whitelist here",
+						Rule:    &rule.TestRule,
+						Finding: "whitelist",
+						Line:    "i have a whitelist here",
 						StartPosition: &token.Position{
 							Filename: filename,
 							Offset:   0,
@@ -281,8 +281,8 @@ func BenchmarkParsePaths(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		p := testParser()
 		pr := new(testPrinter)
-		violations := p.ParsePaths(pr, tmpFile.Name())
-		assert.Equal(b, 1, violations)
+		findings := p.ParsePaths(pr, tmpFile.Name())
+		assert.Equal(b, 1, findings)
 	}
 }
 
@@ -293,7 +293,7 @@ func BenchmarkParsePathsRoot(b *testing.B) {
 		assert.NotPanics(b, func() {
 			p := testParser()
 			pr := new(testPrinter)
-			// Unknown how many violations this will return since it's parsing the whole repo
+			// Unknown how many findings this will return since it's parsing the whole repo
 			// there's no way to know for sure at any given time, so just check that it doesn't panic
 			_ = p.ParsePaths(pr, "../..")
 		})

--- a/pkg/printer/githubactions_test.go
+++ b/pkg/printer/githubactions_test.go
@@ -14,8 +14,8 @@ import (
 
 func TestFormatResultForGitHubAction(t *testing.T) {
 	testResult := result.LineResult{
-		Rule:      &rule.TestRule,
-		Violation: "whitelist",
+		Rule:    &rule.TestRule,
+		Finding: "whitelist",
 		StartPosition: &token.Position{
 			Filename: "my/file",
 			Offset:   0,
@@ -30,7 +30,7 @@ func TestFormatResultForGitHubAction(t *testing.T) {
 		},
 	}
 	got := formatResultForGitHubAction(&testResult)
-	assert.Equal(t, "::warning file=my/file,line=5,col=3::"+testResult.Rule.Reason(testResult.Violation), got)
+	assert.Equal(t, "::warning file=my/file,line=5,col=3::"+testResult.Rule.Reason(testResult.Finding), got)
 }
 
 func TestTranslateSeverityForAction(t *testing.T) {

--- a/pkg/printer/json_test.go
+++ b/pkg/printer/json_test.go
@@ -14,6 +14,6 @@ func TestJSON_Print(t *testing.T) {
 	assert.NoError(t, p.Print(buf, res))
 	got := buf.String()
 
-	expected := `{"Filename":"foo.txt","Results":[{"Rule":{"Name":"whitelist","Terms":["whitelist","white-list","whitelisted","white-listed"],"Alternatives":["allowlist"],"Note":"","Severity":"warning","Options":{"WordBoundary":false,"IncludeNote":null}},"Violation":"whitelist","Line":"this whitelist must change","StartPosition":{"Filename":"foo.txt","Offset":0,"Line":1,"Column":6},"EndPosition":{"Filename":"foo.txt","Offset":0,"Line":1,"Column":15},"Reason":"` + "`whitelist`" + ` may be insensitive, use ` + "`allowlist`" + ` instead"}]}` + "\n"
+	expected := `{"Filename":"foo.txt","Results":[{"Rule":{"Name":"whitelist","Terms":["whitelist","white-list","whitelisted","white-listed"],"Alternatives":["allowlist"],"Note":"","Severity":"warning","Options":{"WordBoundary":false,"IncludeNote":null}},"Finding":"whitelist","Line":"this whitelist must change","StartPosition":{"Filename":"foo.txt","Offset":0,"Line":1,"Column":6},"EndPosition":{"Filename":"foo.txt","Offset":0,"Line":1,"Column":15},"Reason":"` + "`whitelist`" + ` may be insensitive, use ` + "`allowlist`" + ` instead"}]}` + "\n"
 	assert.Equal(t, expected, got)
 }

--- a/pkg/printer/text_test.go
+++ b/pkg/printer/text_test.go
@@ -24,21 +24,21 @@ func TestText_arrowUnderLine(t *testing.T) {
 	p := NewText(true)
 
 	r := result.LineResult{
-		Line:          "this line has black-list as a violation",
+		Line:          "this line has black-list as a finding",
 		StartPosition: newPosition("foo.txt", 4, 14),
 		EndPosition:   newPosition("foo.txt", 4, 24),
 	}
 	assert.Equal(t, "              ^", p.arrowUnderLine(&r))
 
 	r = result.LineResult{
-		Line:          "    this line has black-list as a violation",
+		Line:          "    this line has black-list as a finding",
 		StartPosition: newPosition("foo.txt", 4, 18),
 		EndPosition:   newPosition("foo.txt", 4, 28),
 	}
 	assert.Equal(t, "                  ^", p.arrowUnderLine(&r))
 
 	r = result.LineResult{
-		Line:          "\tthis line has black-list as a violation",
+		Line:          "\tthis line has black-list as a finding",
 		StartPosition: newPosition("foo.txt", 4, 15),
 		EndPosition:   newPosition("foo.txt", 4, 25),
 	}

--- a/pkg/printer/util_test.go
+++ b/pkg/printer/util_test.go
@@ -16,9 +16,9 @@ func generateFileResult() *result.FileResults {
 func generateResults(filename string) []result.Result {
 	return []result.Result{
 		result.LineResult{
-			Rule:      &rule.TestRule,
-			Violation: "whitelist",
-			Line:      "this whitelist must change",
+			Rule:    &rule.TestRule,
+			Finding: "whitelist",
+			Line:    "this whitelist must change",
 			StartPosition: &token.Position{
 				Filename: filename,
 				Offset:   0,

--- a/pkg/result/fileresult_test.go
+++ b/pkg/result/fileresult_test.go
@@ -14,7 +14,7 @@ func TestFileResult_String(t *testing.T) {
 	fr := FileResults{Filename: "my/file", Results: rs}
 	assert.Equal(t, "my/file\n    my/file:1:18-my/file:1:27 warning    `whitelist` may be insensitive, use `allowlist` instead", fr.String())
 
-	rs = FindResults(&rule.TestRule, "my/file", "this has no rule violations", 1)
+	rs = FindResults(&rule.TestRule, "my/file", "this has no rule findings", 1)
 	fr = FileResults{Filename: "my/file", Results: rs}
 	assert.Equal(t, "my/file", fr.String())
 }

--- a/pkg/result/lineresult.go
+++ b/pkg/result/lineresult.go
@@ -9,14 +9,14 @@ import (
 )
 
 // MaxLineLength is the max line length that this printer
-// will show the source of the violation and the location within the line of the violation.
-// Helps avoid consuming the console when minified files contain violations.
+// will show the source of the finding and the location within the line of the finding.
+// Helps avoid consuming the console when minified files contain findings.
 const MaxLineLength = 200
 
 // LineResult contains data about the result of a broken rule
 type LineResult struct {
-	Rule      *rule.Rule
-	Violation string
+	Rule    *rule.Rule
+	Finding string
 	// Line is the full string of the line, unless it's over MaxLintLength,
 	// where Line will be an empty string
 	Line          string
@@ -24,11 +24,11 @@ type LineResult struct {
 	EndPosition   *token.Position
 }
 
-// NewLineResult returns a LineResult based on the metadata from a violation
-func NewLineResult(r *rule.Rule, violation, filename string, line, startColumn, endColumn int) LineResult {
+// NewLineResult returns a LineResult based on the metadata from a finding
+func NewLineResult(r *rule.Rule, finding, filename string, line, startColumn, endColumn int) LineResult {
 	return LineResult{
-		Rule:      r,
-		Violation: violation,
+		Rule:    r,
+		Finding: finding,
 		StartPosition: &token.Position{
 			Filename: filename,
 			Line:     line,
@@ -63,7 +63,7 @@ func FindResults(r *rule.Rule, filename, text string, line int) (rs []Result) {
 
 // Reason outputs the suggested alternatives for this rule
 func (r LineResult) Reason() string {
-	return r.Rule.ReasonWithNote(r.Violation)
+	return r.Rule.ReasonWithNote(r.Finding)
 }
 
 func (r LineResult) String() string {

--- a/pkg/result/lineresult_test.go
+++ b/pkg/result/lineresult_test.go
@@ -16,10 +16,10 @@ func TestFindResults(t *testing.T) {
 	assert.Equal(t, rule.TestRule.Reason("whitelist"), rs[0].Reason())
 	assert.Equal(t, fmt.Sprintf("    my/file:1:18-my/file:1:27 warning    %s", rs[0].Reason()), rs[0].String())
 
-	rs = FindResults(&rule.TestRule, "my/file", "this has no rule violations", 1)
+	rs = FindResults(&rule.TestRule, "my/file", "this has no rule findings", 1)
 	assert.Len(t, rs, 0)
 
-	// inline-ignoring is handled in Parser.generateFileViolations, not FindResults
+	// inline-ignoring is handled in Parser.generateFileFindings, not FindResults
 	rs = FindResults(&rule.TestRule, "my/file", "this has the term whitelist #wokeignore:rule=whitelist", 1)
 	assert.Len(t, rs, 1)
 }
@@ -54,7 +54,7 @@ func TestLineResult_GetLine(t *testing.T) {
 func testLineResult() LineResult {
 	return LineResult{
 		Rule:          &rule.TestRule,
-		Violation:     "whitelist",
+		Finding:       "whitelist",
 		Line:          "whitelist",
 		StartPosition: &token.Position{Line: 1, Offset: 0},
 		EndPosition:   &token.Position{Line: 1, Offset: 8},

--- a/pkg/result/pathresult.go
+++ b/pkg/result/pathresult.go
@@ -7,16 +7,16 @@ import (
 	"github.com/get-woke/woke/pkg/rule"
 )
 
-// PathResult is a Result meant for showing violations in a file path
+// PathResult is a Result meant for showing findings in a file path
 type PathResult struct {
 	LineResult
 }
 
-// Reason is the reason for the PathResult violation.
-// It is similar to Result.Reason, but makes it clear that the violation is
+// Reason is the reason for the PathResult finding.
+// It is similar to Result.Reason, but makes it clear that the finding is
 // with the file path and not a line in the file
 func (r PathResult) Reason() string {
-	return "Filename violation: " + r.Rule.ReasonWithNote(r.LineResult.Violation)
+	return "Filename finding: " + r.Rule.ReasonWithNote(r.LineResult.Finding)
 }
 
 // MatchPathRules will match the path against all the rules provided

--- a/pkg/result/pathresult_test.go
+++ b/pkg/result/pathresult_test.go
@@ -24,7 +24,7 @@ func TestMatchPathRules(t *testing.T) {
 			pr := MatchPathRules(rule.DefaultRules, test.path)
 			assert.Len(t, pr, test.matches)
 			for _, p := range pr {
-				assert.Equal(t, "Filename violation: "+p.Rule.Reason(p.LineResult.Violation), p.Reason())
+				assert.Equal(t, "Filename finding: "+p.Rule.Reason(p.LineResult.Finding), p.Reason())
 			}
 		})
 	}
@@ -54,7 +54,7 @@ func TestMatchPathRulesBoundary(t *testing.T) {
 			pr := MatchPathRules(defaultRules, test.path)
 			assert.Len(t, pr, test.matches)
 			for _, p := range pr {
-				assert.Equal(t, "Filename violation: "+p.Rule.Reason(p.LineResult.Violation), p.Reason())
+				assert.Equal(t, "Filename finding: "+p.Rule.Reason(p.LineResult.Finding), p.Reason())
 			}
 		})
 	}

--- a/pkg/result/result.go
+++ b/pkg/result/result.go
@@ -6,7 +6,7 @@ import (
 	"github.com/get-woke/woke/pkg/rule"
 )
 
-// Result is an interface for a violation of a rule
+// Result is an interface for a finding of a rule
 type Result interface {
 	GetSeverity() rule.Severity
 	GetStartPosition() *token.Position

--- a/pkg/rule/rule.go
+++ b/pkg/rule/rule.go
@@ -31,7 +31,7 @@ func (r *Rule) findAllStringSubmatchIndex(text string) [][]int {
 	return r.re.FindAllStringSubmatchIndex(text, -1)
 }
 
-// FindMatchIndexes returns the start and end indexes for all rule violations for the text supplied.
+// FindMatchIndexes returns the start and end indexes for all rule findings for the text supplied.
 func (r *Rule) FindMatchIndexes(text string) [][]int {
 	if r.Disabled() {
 		return [][]int(nil)
@@ -98,16 +98,16 @@ func (r *Rule) SetRegexp() {
 	r.re = regexp.MustCompile(fmt.Sprintf(`(?i)(%s)`, group))
 }
 
-// Reason returns a human-readable reason for the rule violation
-func (r *Rule) Reason(violation string) string {
-	// fall back to the rule name if no violation was found
-	// violation is mostly used for informational purposes
-	if len(violation) == 0 {
-		violation = r.Name
+// Reason returns a human-readable reason for the rule finding
+func (r *Rule) Reason(finding string) string {
+	// fall back to the rule name if no finding was found
+	// finding is mostly used for informational purposes
+	if len(finding) == 0 {
+		finding = r.Name
 	}
 
 	reason := new(strings.Builder)
-	reason.WriteString(util.MarkdownCodify(violation) + " may be insensitive, ")
+	reason.WriteString(util.MarkdownCodify(finding) + " may be insensitive, ")
 
 	if len(r.Alternatives) > 0 {
 		alt := make([]string, len(r.Alternatives))
@@ -129,19 +129,19 @@ func (r *Rule) includeNote() bool {
 	return false
 }
 
-// ReasonWithNote returns a human-readable reason for the rule violation
+// ReasonWithNote returns a human-readable reason for the rule finding
 // with an additional note, if defined.
-func (r *Rule) ReasonWithNote(violation string) string {
+func (r *Rule) ReasonWithNote(finding string) string {
 	if len(r.Note) == 0 || !r.includeNote() {
-		return r.Reason(violation)
+		return r.Reason(finding)
 	}
-	return fmt.Sprintf("%s (%s)", r.Reason(violation), r.Note)
+	return fmt.Sprintf("%s (%s)", r.Reason(finding), r.Note)
 }
 
 // CanIgnoreLine returns a boolean value if the line contains the ignore directive.
 // For example, if a line has anywhere, wokeignore:rule=whitelist
 // (should be commented out via whatever the language comment syntax is)
-// it will not report that line in violation with the Rule with the name `whitelist` wokeignore:rule=whitelist
+// it will not report that line in finding with the Rule with the name `whitelist` wokeignore:rule=whitelist
 func (r *Rule) CanIgnoreLine(line string) bool {
 	matches := ignoreRuleRegex.FindAllStringSubmatch(line, -1)
 	if matches == nil {
@@ -172,7 +172,7 @@ func escape(ss []string) []string {
 
 // removeInlineIgnore removes the entire match of the ignoreRuleRegex from the line
 // and replaces it with the unicode replacement character so the rule matcher won't
-// attempt to find violations within
+// attempt to find findings within
 func removeInlineIgnore(line string) string {
 	inlineIgnoreMatch := ignoreRuleRegex.FindStringIndex(line)
 	if inlineIgnoreMatch == nil || len(inlineIgnoreMatch) < 2 {

--- a/pkg/rule/rule_test.go
+++ b/pkg/rule/rule_test.go
@@ -16,8 +16,8 @@ func TestRule_FindMatchIndexes(t *testing.T) {
 	}{
 		{"this string has rule-1 and rule1 included", [][]int{{16, 22}, {27, 32}}, [][]int{{16, 22}, {27, 32}}},
 		{"this string has rule-2 and rule1 included", [][]int{{27, 32}}, [][]int{{27, 32}}},
-		{"this string does not have any violations", [][]int(nil), [][]int(nil)},
-		{"this string has violation with word boundary rule1rule-1", [][]int{{45, 50}, {50, 56}}, [][]int(nil)},
+		{"this string does not have any findings", [][]int(nil), [][]int(nil)},
+		{"this string has finding with word boundary rule1rule-1", [][]int{{43, 48}, {48, 54}}, [][]int(nil)},
 	}
 	for _, test := range tests {
 		got := r.FindMatchIndexes(test.text)
@@ -70,16 +70,16 @@ func TestRule_CanIgnoreLine(t *testing.T) {
 		line      string
 		assertion assert.BoolAssertionFunc
 	}{
-		{"violation without comment", "rule1", assert.False},
-		{"violation with correct comment", "rule1 #wokeignore:rule=rule1", assert.True},
-		{"violation with space as rule", "rule1 #wokeignore:rule= ", assert.False},
-		{"violation with invalid comment", "rule1 #wokeignore:rule", assert.False},
-		{"violation with tab as rule", "rule1 #wokeignore:rule=\t", assert.False},
-		{"violation with multiple rules", "rule1 #wokeignore:rule=rule1,rule2", assert.True},
-		{"violation with incorrect comment", "rule1 #wokeignore:rule=rule2", assert.False},
-		{"no violation with correct comment", "rule2 #wokeignore:rule=rule1", assert.True},
-		{"violation with text after ignore", "rule1 #wokeignore:rule=rule1 something else", assert.True},
-		{"violation with multiple ignores", "rule1 #wokeignore:rule=rule1 wokeignore:rule=rule2", assert.True},
+		{"finding without comment", "rule1", assert.False},
+		{"finding with correct comment", "rule1 #wokeignore:rule=rule1", assert.True},
+		{"finding with space as rule", "rule1 #wokeignore:rule= ", assert.False},
+		{"finding with invalid comment", "rule1 #wokeignore:rule", assert.False},
+		{"finding with tab as rule", "rule1 #wokeignore:rule=\t", assert.False},
+		{"finding with multiple rules", "rule1 #wokeignore:rule=rule1,rule2", assert.True},
+		{"finding with incorrect comment", "rule1 #wokeignore:rule=rule2", assert.False},
+		{"no finding with correct comment", "rule2 #wokeignore:rule=rule1", assert.True},
+		{"finding with text after ignore", "rule1 #wokeignore:rule=rule1 something else", assert.True},
+		{"finding with multiple ignores", "rule1 #wokeignore:rule=rule1 wokeignore:rule=rule2", assert.True},
 	}
 
 	for _, tt := range tests {

--- a/testdata/good.yml
+++ b/testdata/good.yml
@@ -1,2 +1,2 @@
 ---
-this file has no violations.
+this file has no findings.

--- a/testdata/whitelist.yml
+++ b/testdata/whitelist.yml
@@ -1,2 +1,2 @@
 ---
-this file also has a whitelist violation
+this file also has a whitelist finding


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The commit message follows our [guidelines](https://github.com/get-woke/woke/blob/main/CONTRIBUTING.md)
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Semantics update 


**What is the current behavior?** (You can also link to an open issue here)
The term `violations` is used significantly, but as noted in #71, has a negative connotation. 


**What is the new behavior (if this is a feature change)?**
Changed all references for `violations` to `findings`



**Does this PR introduce a breaking change?** (What changes might users need to make due to this PR?)
No breaking change, except that woke will now output `No findings found. Stay woke ✊` instead of `No violations found. Stay woke ✊`

**Other information**:
Closes #71 