### PR TITLE
removal of non-inclusive emoji.

### DIFF
--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -74,7 +74,7 @@ func TestRunE(t *testing.T) {
 		assert.NoError(t, err)
 
 		got := buf.String()
-		expected := "No findings found. Stay woke \u270a\n"
+		expected := "No findings found.\n"
 		assert.Equal(t, expected, got)
 	})
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -52,7 +52,7 @@ func NewConfig(filename string) (*Config, error) {
 
 func (c *Config) GetSuccessExitMessage() string {
 	if c.SuccessExitMessage == nil {
-		return "No findings found. Stay woke ✊"
+		return "No findings found."
 	}
 	return *c.SuccessExitMessage
 }

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -66,7 +66,7 @@ func TestNewConfig(t *testing.T) {
 		assert.EqualValues(t, expected.Rules, c.Rules)
 
 		// check default config message
-		assert.Equal(t, "No findings found. Stay woke ✊", c.GetSuccessExitMessage())
+		assert.Equal(t, "No findings found.", c.GetSuccessExitMessage())
 	})
 
 	t.Run("config-empty-missing", func(t *testing.T) {


### PR DESCRIPTION
The fist emoji is not inclusive of those within the differently-abled community,
such as amputees, people with symbrachydactyly, and persons who have fully-formed
hands but are unable to form them into a fist due to neuromuscular conditions.

It also can't be rendered properly in text-mode terminals.

**Please check if the PR fulfills these requirements**

- [x] The commit message follows our [guidelines](https://github.com/get-woke/woke/blob/main/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)



**What is the current behavior?** (You can also link to an open issue here)



**What is the new behavior (if this is a feature change)?**



**Does this PR introduce a breaking change?** (What changes might users need to make due to this PR?)


**Other information**:
