### PR TITLE
remove os specific paths

### DIFF
--- a/pkg/ignore/ignore_test.go
+++ b/pkg/ignore/ignore_test.go
@@ -17,6 +17,11 @@ func TestIgnore_Match(t *testing.T) {
 	i := NewIgnore([]string{"my/files/*"})
 	assert.NotNil(t, i)
 
+	// Test if rules with backslashes match on windows
+	assert.False(t, i.Match("not/foo"))
+	assert.True(t, i.Match("my/files/file1"))
+	assert.False(t, i.Match("my/files"))
+
 	assert.False(t, i.Match(filepath.Join("not", "foo")))
 	assert.True(t, i.Match(filepath.Join("my", "files", "file1")))
 	assert.False(t, i.Match(filepath.Join("my", "files")))

--- a/pkg/ignore/ignore_test.go
+++ b/pkg/ignore/ignore_test.go
@@ -2,7 +2,7 @@ package ignore
 
 import (
 	"os"
-	"runtime"
+	"path/filepath"
 	"testing"
 
 	"github.com/rs/zerolog"
@@ -17,15 +17,9 @@ func TestIgnore_Match(t *testing.T) {
 	i := NewIgnore([]string{"my/files/*"})
 	assert.NotNil(t, i)
 
-	assert.False(t, i.Match("not/foo"))
-	assert.True(t, i.Match("my/files/file1"))
-	assert.False(t, i.Match("my/files"))
-
-	if runtime.GOOS == "windows" {
-		assert.False(t, i.Match(`not\foo`))
-		assert.True(t, i.Match(`my\files\file1`))
-		assert.False(t, i.Match(`my\files`))
-	}
+	assert.False(t, i.Match(filepath.Join("not", "foo")))
+	assert.True(t, i.Match(filepath.Join("my", "files", "file1")))
+	assert.False(t, i.Match(filepath.Join("my", "files")))
 }
 
 // Test all default ignore files, except for .git/info/exclude, since


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The commit message follows our [guidelines](https://github.com/get-woke/woke/blob/main/CONTRIBUTING.md)
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Feature 


**What is the current behavior?** (You can also link to an open issue here)

In `pkg/ignore/ignore_test.go` there are two separate tests one for each OS path. 


**What is the new behavior (if this is a feature change)?**

Combine the two separate literal os paths with one dynamic path using the `path/filepath` library. That way we only need to maintain one set of tests. 


**Does this PR introduce a breaking change?** (What changes might users need to make due to this PR?)

No

**Other information**:
