### PR TITLE
Add `.git/info/exclude` to default ignore files

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,7 +271,7 @@ ignore_files:
   - globs/too/*
 ```
 
-`woke` will also automatically ignore anything listed in `.gitignore`.
+`woke` will also automatically ignore anything listed in `.gitignore` and `.git/info/exclude`.
 
 #### `.wokeignore`
 

--- a/pkg/ignore/ignore.go
+++ b/pkg/ignore/ignore.go
@@ -16,7 +16,13 @@ type Ignore struct {
 	matcher *gitignore.GitIgnore
 }
 
-// NewIgnore produces an Ignore object, with compiled lines from .gitignore and DefaultIgnores
+var defaultIgnoreFiles = []string{
+	".gitignore",
+	".wokeignore",
+	".git/info/exclude",
+}
+
+// NewIgnore produces an Ignore object, with compiled lines from defaultIgnoreFiles
 // which you can match files against
 func NewIgnore(lines []string) *Ignore {
 	start := time.Now()
@@ -26,8 +32,9 @@ func NewIgnore(lines []string) *Ignore {
 			Msg("finished compiling ignores")
 	}()
 
-	lines = append(lines, readIgnoreFile(".gitignore")...)
-	lines = append(lines, readIgnoreFile(".wokeignore")...)
+	for _, filename := range defaultIgnoreFiles {
+		lines = append(lines, readIgnoreFile(filename)...)
+	}
 
 	ignorer := Ignore{
 		matcher: gitignore.CompileIgnoreLines(lines...),


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The commit message follows our [guidelines](https://github.com/get-woke/woke/blob/main/CONTRIBUTING.md)
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Feature


**What is the current behavior?** (You can also link to an open issue here)
Woke does not recognize locally-defined ignores in `.git/info/exclude`, which git recognizes (https://git-scm.com/docs/gitignore)


**What is the new behavior (if this is a feature change)?**
Add lines in `.git/info/exclude` to the Ignorer in woke so those files will also be ignored now.


**Does this PR introduce a breaking change?** (What changes might users need to make due to this PR?)
No, and since `.git/info/exclude` is a local configuration, this will have no impact on CI

**Other information**:
Closes #102 
