### PR TITLE
bug: Add back case insensitivity to rule regex

### DIFF
--- a/pkg/rule/rule.go
+++ b/pkg/rule/rule.go
@@ -89,6 +89,7 @@ func (r *Rule) setRegex() {
 func (r *Rule) regexString() string {
 	regex := func(start, end string) string {
 		s := strings.Builder{}
+		s.WriteString("(?i)")
 		s.WriteString(start)
 		s.WriteString("(%s)")
 		s.WriteString(end)

--- a/pkg/rule/rule_test.go
+++ b/pkg/rule/rule_test.go
@@ -31,6 +31,7 @@ func TestRule_FindMatchIndexes(t *testing.T) {
 		{"this string has rule-2 and rule1 included", [][]int{{27, 32}}, [][]int{{27, 32}}},
 		{"this string does not have any findings", [][]int(nil), [][]int(nil)},
 		{"this string has finding with word boundary rule1rule-1", [][]int{{43, 48}, {48, 54}}, [][]int(nil)},
+		{"this string has finding with word boundary Rule1rule-1", [][]int{{43, 48}, {48, 54}}, [][]int(nil)},
 	}
 	for _, test := range tests {
 		r := testRule()

--- a/pkg/rule/rule_test.go
+++ b/pkg/rule/rule_test.go
@@ -126,33 +126,33 @@ func TestRule_regexString(t *testing.T) {
 		{
 			desc:     "default",
 			rule:     testRule(),
-			expected: `(%s)`,
+			expected: `(?i)(%s)`,
 		},
 		{
 			desc:     "word boundary",
 			rule:     testRuleWithOptions(Options{WordBoundary: true}),
-			expected: `\b(%s)\b`,
+			expected: `(?i)\b(%s)\b`,
 		},
 		{
 			desc:     "word boundary start",
 			rule:     testRuleWithOptions(Options{WordBoundaryStart: true}),
-			expected: `\b(%s)`,
+			expected: `(?i)\b(%s)`,
 		},
 		{
 			desc:     "word boundary end",
 			rule:     testRuleWithOptions(Options{WordBoundaryEnd: true}),
-			expected: `(%s)\b`,
+			expected: `(?i)(%s)\b`,
 		},
 		{
 			desc:     "word boundary start and end",
 			rule:     testRuleWithOptions(Options{WordBoundaryStart: true, WordBoundaryEnd: true}),
-			expected: `\b(%s)\b`,
+			expected: `(?i)\b(%s)\b`,
 		},
 		{
 			// To show that enabling WordBoundary will win over other options
 			desc:     "word boundary and word boundary start/end false",
 			rule:     testRuleWithOptions(Options{WordBoundary: true, WordBoundaryStart: false, WordBoundaryEnd: false}),
-			expected: `\b(%s)\b`,
+			expected: `(?i)\b(%s)\b`,
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The commit message follows our [guidelines](https://github.com/get-woke/woke/blob/main/CONTRIBUTING.md)
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix


**What is the current behavior?** (You can also link to an open issue here)
I accidentally removed `(?i)` in #100 so it no longer matches with case insensitivity


**What is the new behavior (if this is a feature change)?**
Add back case insensitivity


**Does this PR introduce a breaking change?** (What changes might users need to make due to this PR?)
No

**Other information**:
Fixes #108 