### PR TITLE
Use null terminator for masking inline ignore

### DIFF
--- a/pkg/result/lineresult_test.go
+++ b/pkg/result/lineresult_test.go
@@ -22,6 +22,8 @@ func TestFindResults(t *testing.T) {
 	// inline-ignoring is handled in Parser.generateFileFindings, not FindResults
 	rs = FindResults(&rule.TestRule, "my/file", "this has the term whitelist #wokeignore:rule=whitelist", 1)
 	assert.Len(t, rs, 1)
+	rs = FindResults(&rule.TestRule, "my/file", "/* wokeignore:rule=whitelist */ this has the term whitelist", 1)
+	assert.Len(t, rs, 1)
 }
 
 func TestLineResult_MarshalJSON(t *testing.T) {

--- a/pkg/rule/rule.go
+++ b/pkg/rule/rule.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"regexp"
 	"strings"
-	"unicode"
 
 	"github.com/get-woke/woke/pkg/util"
 )
@@ -198,7 +197,8 @@ func removeInlineIgnore(line string) string {
 	end := inlineIgnoreMatch[1]
 
 	for i := start; i < end; i++ {
-		lineWithoutIgnoreRule[i] = unicode.ReplacementChar
+		// use null terminator to indicate a masked character
+		lineWithoutIgnoreRule[i] = rune(0)
 	}
 
 	return string(lineWithoutIgnoreRule)

--- a/pkg/rule/rule.go
+++ b/pkg/rule/rule.go
@@ -33,7 +33,7 @@ func (r *Rule) FindMatchIndexes(text string) [][]int {
 	r.SetRegexp()
 
 	// Remove inline ignores from text to avoid matching against other rules
-	matches := r.re.FindAllStringSubmatchIndex(removeInlineIgnore(text), -1)
+	matches := r.re.FindAllStringSubmatchIndex(maskInlineIgnore(text), -1)
 	if matches == nil {
 		return [][]int(nil)
 	}
@@ -182,10 +182,10 @@ func escape(ss []string) []string {
 	return ss
 }
 
-// removeInlineIgnore removes the entire match of the ignoreRuleRegex from the line
-// and replaces it with the unicode replacement character so the rule matcher won't
-// attempt to find findings within
-func removeInlineIgnore(line string) string {
+// maskInlineIgnore removes the entire match of the ignoreRuleRegex from the line
+// and replaces it with the null terminator (\x00) character so the rule matcher won't
+// attempt to find findings within the inline ignore
+func maskInlineIgnore(line string) string {
 	inlineIgnoreMatch := ignoreRuleRegex.FindStringIndex(line)
 	if inlineIgnoreMatch == nil || len(inlineIgnoreMatch) < 2 {
 		return line

--- a/pkg/rule/rule_test.go
+++ b/pkg/rule/rule_test.go
@@ -171,7 +171,7 @@ func Test_removeInlineIgnore(t *testing.T) {
 		{
 			desc:     "replace wokeignore:rule",
 			line:     "wokeignore:rule=master-slave",
-			expected: "����������������������������",
+			expected: "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00",
 		},
 		{
 			desc:     "not replace wokeignore:rule",

--- a/pkg/rule/rule_test.go
+++ b/pkg/rule/rule_test.go
@@ -162,7 +162,7 @@ func TestRule_regexString(t *testing.T) {
 	}
 }
 
-func Test_removeInlineIgnore(t *testing.T) {
+func Test_maskInlineIgnore(t *testing.T) {
 	tests := []struct {
 		desc     string
 		line     string
@@ -181,7 +181,7 @@ func Test_removeInlineIgnore(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.desc, func(t *testing.T) {
-			assert.Equal(t, tt.expected, removeInlineIgnore(tt.line))
+			assert.Equal(t, tt.expected, maskInlineIgnore(tt.line))
 		})
 	}
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The commit message follows our [guidelines](https://github.com/get-woke/woke/blob/main/CONTRIBUTING.md)
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix


**What is the current behavior?** (You can also link to an open issue here)
Use the `unicode.ReplacementChar` � to mask any inline ignores so they don't result in a "finding". This is actually a three byte symbol and causes the matcher to return incorrect and out of bound indexes


**What is the new behavior (if this is a feature change)?**
Switch to using a single byte character to mask inline ignores (null terminator - http://en.wikipedia.org/wiki/Null_character). The goal is to use something that wouldn't trigger any findings 


**Does this PR introduce a breaking change?** (What changes might users need to make due to this PR?)
No

**Other information**:
Fixes #109 
