### PR TITLE
Remove non-inclusive language in .goreleaser

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,4 +1,4 @@
-# This is an example goreleaser.yaml file with some sane defaults.
+# This is an example goreleaser.yaml file with some sensible defaults.
 # Make sure to check the documentation at http://goreleaser.com
 
 before:


### PR DESCRIPTION
Use of the word _sane_ is discouraged by [Google developer documentation style guide](https://developers.google.com/style/word-list).