### PR TITLE
Add `arm64` to build architectures

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -15,6 +15,7 @@ builds:
     goarch:
       - "amd64"
       - "386"
+      - "arm64"
     ldflags: -s -w -X github.com/get-woke/woke/cmd.Version={{.Version}} -X github.com/get-woke/woke/cmd.Commit={{.ShortCommit}} -X github.com/get-woke/woke/cmd.Date={{.Date}}
 
 archives:


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The commit message follows our [guidelines](https://github.com/get-woke/woke/blob/main/CONTRIBUTING.md)
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features) see [docs/README.md](https://github.com/get-woke/woke/blob/main/docs/README.md)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Adds build architecture `arm64` for Apple M1 support


**What is the current behavior?** (You can also link to an open issue here)
Cannot install woke on M1 apple laptops via brew


**What is the new behavior (if this is a feature change)?**
Goreleaser will build arm64 architecture binaries. Requires #145 to support `windows/arm64` (, https://goreleaser.com/deprecations/#builds-for-windowsarm64)


**Does this PR introduce a breaking change?** (What changes might users need to make due to this PR?)
No

**Other information**:
Closes #139 
