### PR TITLE
ci: Disable benchmark PR comments, doesn't work on forks

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -50,52 +50,54 @@ jobs:
 
           exit $EXIT_CODE
 
-      - name: Find Comment
-        uses: peter-evans/find-comment@v1
-        id: comment
-        with:
-          issue-number: ${{ github.event.pull_request.number }}
-          comment-author: 'github-actions[bot]'
-          body-includes: <!-- cob-output -->
+      # FIXME: The action to comment on PRs does not work for forks
+      # https://github.com/peter-evans/create-pull-request/blob/main/docs/concepts-guidelines.md#restrictions-on-repository-forks
+      # - name: Find Comment
+      #   uses: peter-evans/find-comment@v1
+      #   id: comment
+      #   with:
+      #     issue-number: ${{ github.event.pull_request.number }}
+      #     comment-author: 'github-actions[bot]'
+      #     body-includes: <!-- cob-output -->
 
-      - name: Create or update comment if benchmark failed
-        uses: peter-evans/create-or-update-comment@v1
-        if: steps.cob.outputs.exit_code != '0'
-        with:
-          comment-id: ${{ steps.comment.outputs.comment-id }}
-          issue-number: ${{ github.event.pull_request.number }}
-          body: |
-            <!-- cob-output -->
-            ### Benchmark comparison to `origin/main`
+      # - name: Create or update comment if benchmark failed
+      #   uses: peter-evans/create-or-update-comment@v1
+      #   if: steps.cob.outputs.exit_code != '0'
+      #   with:
+      #     comment-id: ${{ steps.comment.outputs.comment-id }}
+      #     issue-number: ${{ github.event.pull_request.number }}
+      #     body: |
+      #       <!-- cob-output -->
+      #       ### Benchmark comparison to `origin/main`
 
-            * Comparison commit: ${{ steps.cob.outputs.base_commit }}
+      #       * Comparison commit: ${{ steps.cob.outputs.base_commit }}
 
-            _This is currently only informational_
+      #       _This is currently only informational_
 
-            **This PR may have a negative performance impact**
+      #       **This PR may have a negative performance impact**
 
-            ```
-            ${{ steps.cob.outputs.result }}
-            ```
-          edit-mode: replace
+      #       ```
+      #       ${{ steps.cob.outputs.result }}
+      #       ```
+      #     edit-mode: replace
 
-      - name: Update comment if benchmark succeeded
-        uses: peter-evans/create-or-update-comment@v1
-        if: steps.comment.outputs.comment-id != '' && steps.cob.outputs.exit_code == '0'
-        with:
-          comment-id: ${{ steps.comment.outputs.comment-id }}
-          issue-number: ${{ github.event.pull_request.number }}
-          body: |
-            <!-- cob-output -->
-            ### Benchmark comparison to `origin/main`
+      # - name: Update comment if benchmark succeeded
+      #   uses: peter-evans/create-or-update-comment@v1
+      #   if: steps.comment.outputs.comment-id != '' && steps.cob.outputs.exit_code == '0'
+      #   with:
+      #     comment-id: ${{ steps.comment.outputs.comment-id }}
+      #     issue-number: ${{ github.event.pull_request.number }}
+      #     body: |
+      #       <!-- cob-output -->
+      #       ### Benchmark comparison to `origin/main`
 
-            * Comparison commit: ${{ steps.cob.outputs.base_commit }}
+      #       * Comparison commit: ${{ steps.cob.outputs.base_commit }}
 
-            _This is currently only informational_
+      #       _This is currently only informational_
 
-            **This PR previously reported a negative performance impact that appears to have been resolved**
+      #       **This PR previously reported a negative performance impact that appears to have been resolved**
 
-            ```
-            ${{ steps.cob.outputs.result }}
-            ```
-          edit-mode: replace
+      #       ```
+      #       ${{ steps.cob.outputs.result }}
+      #       ```
+      #     edit-mode: replace


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The commit message follows our [guidelines](https://github.com/get-woke/woke/blob/main/CONTRIBUTING.md)
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features) see [docs/README.md](https://github.com/get-woke/woke/blob/main/docs/README.md)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Fix for failing benchmark CI test on forks


**What is the current behavior?** (You can also link to an open issue here)
In #118, I wanted to automatically run and compare benchmark tests and comment on the PR with the results. Unfortunately, the github action that does the commenting doesn't work when the PR is opened from a fork.


**What is the new behavior (if this is a feature change)?**
No PR comments for now, until I can investigate further. Benchmarks will still run on CI


**Does this PR introduce a breaking change?** (What changes might users need to make due to this PR?)
No

**Other information**:
