### PR TITLE
Make pre-commit hook more self-contained

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,6 +1,7 @@
 - id: woke
   name: 'woke'
-  entry: woke --exit-1-on-failure
+  entry: woke
+  args: [--exit-1-on-failure]
   # The 'go' binary on your path must be at least version 1.17.
   language: 'golang'
   description: "Runs `woke`"

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,5 +1,6 @@
 - id: woke
   name: 'woke'
-  entry: scripts/pre-commit.sh
-  language: 'script'
+  entry: woke --exit-1-on-failure
+  # The 'go' binary on your path must be at least version 1.17.
+  language: 'golang'
   description: "Runs `woke`"


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The commit message follows our [guidelines](https://github.com/get-woke/woke/blob/main/CONTRIBUTING.md)
- [x] Tests for the changes have been added (N/A)
- [x] Docs have been added / updated (N/A)


**What kind of change does this PR introduce?**

`pre-commit` hook update.

**What is the current behavior?** (You can also link to an open issue here)

The previous `pre-commit` hook declaration, using `language: 'script'`, relied on `woke` already being installed on the user's path, which is a somewhat awkward requirement compared to most other `pre-commit` hooks which tend to be self-contained.  It also meant that it wasn't possible to pin `woke` to a particular version on a per-repository basis using something like `rev: v0.15.0`.

**What is the new behavior (if this is a feature change)?**

Using `language: 'golang'` instead means that `pre-commit` builds a self-contained installation of `woke` for itself.  The only downside is that the `go` binary on the user's path must be at least version 1.17, which can be a bit annoying (for example, on Ubuntu 20.04 it requires using something like the `go` snap rather than the .deb).  However, this will become less of a problem over time.

I left `scripts/pre-commit.sh` in place so that people can still easily use the old approach if they prefer it, albeit by declaring a custom hook.

**Does this PR introduce a breaking change?** (What changes might users need to make due to this PR?)

`pre-commit` hook users may need to ensure that they have Go 1.17 or newer on their system path.