### PR TITLE
Add a more self-contained pre-commit hook

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -3,3 +3,10 @@
   entry: scripts/pre-commit.sh
   language: 'script'
   description: "Runs `woke`"
+- id: woke-from-source
+  name: 'woke'
+  entry: woke
+  args: [--exit-1-on-failure]
+  # The 'go' binary on your path must be at least version 1.17.
+  language: 'golang'
+  description: "Runs `woke`, building it from source on demand"

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -4,3 +4,40 @@
 - [GitHub Action (reviewdog)](https://github.com/marketplace/actions/run-woke-with-reviewdog)
 - [VS Code Extension](https://marketplace.visualstudio.com/items?itemName=get-woke.vscode-woke)
 - [VIM Plugin](https://github.com/get-woke/vim-woke)
+
+## Pre-commit hook
+
+`woke` supports being run from a [pre-commit](https://pre-commit.com/) hook,
+allowing you to avoid accidentally committing uses of non-inclusive
+language.
+You have two alternative mechanisms for doing so.
+If you have arranged to install `woke` on your command search path (as well
+as anyone working on your repository), then add this configuration to your
+`.pre-commit-config.yaml`:
+
+```yaml
+-   repo: https://github.com/get-woke/woke
+    rev: ''  # pick a tag to point to
+    hooks:
+    -   woke
+```
+
+(Note that in this case the `rev` only controls the version of a wrapper
+script that is used, not the version of `woke` itself.)
+
+Alternatively, you can tell `pre-commit` to build `woke` from source,
+although this requires you and anyone working on your repository to have
+`go` on your command search path and for it to be at least version 1.17:
+
+```yaml
+-   repo: https://github.com/get-woke/woke
+    rev: ''  # pick a tag to point to
+    hooks:
+    -   woke-from-source
+```
+
+(In this case the `rev` controls the version of `woke` itself.)
+
+See the [pre-commit
+documentation](https://pre-commit.com/#pre-commit-configyaml---hooks) for
+how to customize this further.


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The commit message follows our [guidelines](https://github.com/get-woke/woke/blob/main/CONTRIBUTING.md)
- [x] Tests for the changes have been added (N/A)
- [x] Docs have been added / updated


**What kind of change does this PR introduce?**

New alternative `pre-commit` hook, and corresponding documentation.

**What is the current behavior?** (You can also link to an open issue here)

The previous `pre-commit` hook declaration, using `language: 'script'`, relied on `woke` already being installed on the user's path, which is a somewhat awkward requirement compared to most other `pre-commit` hooks which tend to be self-contained.  It also meant that it wasn't possible to pin `woke` to a particular version on a per-repository basis using something like `rev: v0.15.0`.

**What is the new behavior (if this is a feature change)?**

Using `language: 'golang'` instead means that `pre-commit` builds a self-contained installation of `woke` for itself.  The only downside is that the `go` binary on the user's path must be at least version 1.17, which can be a bit annoying (for example, on Ubuntu 20.04 it requires using something like the `go` snap rather than the .deb).  However, this will become less of a problem over time.

In order to avoid a breaking change for people already using the old approach, I added this as a new alternative hook, called `woke-from-source`.

Add documentation for all this.

**Does this PR introduce a breaking change?** (What changes might users need to make due to this PR?)

No - the previous hook is left unchanged.  Users may wish to migrate to the new hook if it fits their needs better.

This is an alternative to #152.