### PR TITLE
ci: Use go 1.17 for pkg.go.dev update action

### DIFF
--- a/.github/workflows/go-docs.yml
+++ b/.github/workflows/go-docs.yml
@@ -10,5 +10,24 @@ jobs:
     name: Renew documentation
     runs-on: ubuntu-latest
     steps:
-    - name: Pull new module version
-      uses: andrewslotin/go-proxy-pull-action@v1.0.2
+      - uses: actions/setup-go@v2
+        with:
+          go-version: 1.17
+
+      - name: Pull new module version
+        # Based on andrewslotin/go-proxy-pull-action
+        # https://github.com/andrewslotin/go-proxy-pull-action/issues/5
+        run: |
+          TAG=${GITHUB_REF#refs/tags/*}
+          VERSION=${TAG##*/}
+
+          PACKAGE=github.com/${GITHUB_REPOSITORY}
+          if [[ "$VERSION" != "$TAG" ]]; then
+            PACKAGE=github.com/${GITHUB_REPOSITORY}/${TAG%"/$VERSION"}
+          fi
+
+          # https://pkg.go.dev/about#adding-a-package
+          export GO111MODULE=on
+          export GOPROXY="https://proxy.golang.org"
+
+          go get -d "$PACKAGE@$VERSION"


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The commit message follows our [guidelines](https://github.com/get-woke/woke/blob/main/CONTRIBUTING.md)
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features) see [docs/README.md](https://github.com/get-woke/woke/blob/main/docs/README.md)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
CI


**What is the current behavior?** (You can also link to an open issue here)
When new tags are pushed, there's a github action that's supposed to update pkg.go.dev. It's currently failing: https://github.com/get-woke/woke/runs/5611605439?check_suite_focus=true. I opened an issue with the action owner: https://github.com/andrewslotin/go-proxy-pull-action/issues/5


**What is the new behavior (if this is a feature change)?**
Remove usage of the `andrewslotin/go-proxy-pull-action` action and run the update manually


**Does this PR introduce a breaking change?** (What changes might users need to make due to this PR?)
No

**Other information**:
