### PR TITLE
build(deps): bump golangci/golangci-lint-action from 2.5.2 to 3.1.0

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -91,4 +91,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: golangci/golangci-lint-action@v2.5.2
+      - uses: actions/setup-go@v2
+        with:
+          go-version: ${{ matrix.go-version }}
+      - uses: golangci/golangci-lint-action@v3.1.0


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The commit message follows our [guidelines](https://github.com/get-woke/woke/blob/main/CONTRIBUTING.md)
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features) see [docs/README.md](https://github.com/get-woke/woke/blob/main/docs/README.md)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Dependency update


**What is the current behavior?** (You can also link to an open issue here)
Github action upgrade to v3 of golangci-lint-action - https://github.com/golangci/golangci-lint-action#compatibility


**What is the new behavior (if this is a feature change)?**



**Does this PR introduce a breaking change?** (What changes might users need to make due to this PR?)
No

**Other information**:
Supersedes #176