### PR TITLE
[bugfix] Fix error when running with submodules

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/caitlinelfring/go-env-default v1.0.0
 	github.com/fatih/color v1.13.0
 	github.com/get-woke/fastwalk v1.0.0
-	github.com/get-woke/go-git/v5 v5.4.5
+	github.com/get-woke/go-git/v5 v5.4.6
 	github.com/go-git/go-billy/v5 v5.3.1
 	github.com/mattn/go-colorable v0.1.12
 	github.com/mitchellh/go-homedir v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -99,8 +99,8 @@ github.com/fsnotify/fsnotify v1.5.1 h1:mZcQUHVQUQWoPXXtuf9yuEXKudkV2sx1E06UadKWp
 github.com/fsnotify/fsnotify v1.5.1/go.mod h1:T3375wBYaZdLLcVNkcVbzGHY7f1l/uK5T5Ai1i3InKU=
 github.com/get-woke/fastwalk v1.0.0 h1:Ti8z9nf231TUhLzBuJQV/rh/b5qiuyPunYun4FpEshQ=
 github.com/get-woke/fastwalk v1.0.0/go.mod h1:WTDsePalrkZGMzdzn5YabupFqFmU/MjxGM2CSSc9sOo=
-github.com/get-woke/go-git/v5 v5.4.5 h1:s6fLBDcbOFdCF49TBioH8PeD+TVsLrhYIpZxCLbDo1o=
-github.com/get-woke/go-git/v5 v5.4.5/go.mod h1:FjlV7R/wWHBz6ksfGv7Q4r5P7CboJKSxPknWf6FmMf4=
+github.com/get-woke/go-git/v5 v5.4.6 h1:A8eJI4lb1y9VYhAoUdbNpZ8B8bYjkNKQmjpgbMnYOz4=
+github.com/get-woke/go-git/v5 v5.4.6/go.mod h1:FjlV7R/wWHBz6ksfGv7Q4r5P7CboJKSxPknWf6FmMf4=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/gliderlabs/ssh v0.2.2/go.mod h1:U7qILu1NlMHj9FlMhZLlkCdDnU1DBEAqr0aevW3Awn0=
 github.com/go-git/gcfg v1.5.0 h1:Q5ViNfGF8zFgyJWPqYwA7qGFoMTEiBmdlkcfRmpIMa4=

--- a/pkg/ignore/ignore.go
+++ b/pkg/ignore/ignore.go
@@ -23,7 +23,6 @@ var defaultIgnoreFiles = []string{
 	".gitignore",
 	".ignore",
 	".wokeignore",
-	".git/info/exclude",
 }
 
 // Given a workingDir (example: /root/proj/subDir/curDir)


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The commit message follows our [guidelines](https://github.com/get-woke/woke/blob/main/CONTRIBUTING.md)
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features) see [docs/README.md](https://github.com/get-woke/woke/blob/main/docs/README.md)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix


**What is the current behavior?** (You can also link to an open issue here)
`.git/info/exclude` is explicitly listed as an "gitignore" file when building the list of patterns that will be ignored when running woke. It's causing issues when using submodules, since the ignorer library woke uses will recursively search for these ignore files, but submodules `.git` is actually a link and causes woke to fail. 


**What is the new behavior (if this is a feature change)?**
In a newer version of the go-git library that woke uses to compile the ignore patterns, parsing `.git/info/exclude` is handled by default and is not needed explicitly within woke anymore.
* https://github.com/get-woke/go-git/pull/1
* https://github.com/go-git/go-git/pull/402


**Does this PR introduce a breaking change?** (What changes might users need to make due to this PR?)
No

**Other information**:
Fixes #192 