### PR TITLE
[bug fix] Add arm64 to bash installer script

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -65,10 +65,13 @@ get_binaries() {
   case "$PLATFORM" in
     darwin/386) BINARIES="woke" ;;
     darwin/amd64) BINARIES="woke" ;;
+    darwin/arm64) BINARIES="woke" ;;
     linux/386) BINARIES="woke" ;;
     linux/amd64) BINARIES="woke" ;;
+    linux/arm64) BINARIES="woke" ;;
     windows/386) BINARIES="woke" ;;
     windows/amd64) BINARIES="woke" ;;
+    windows/arm64) BINARIES="woke" ;;
     *)
       log_crit "platform $PLATFORM is not supported.  Make sure this script is up-to-date and file request at https://github.com/${PREFIX}/issues/new"
       exit 1


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The commit message follows our [guidelines](https://github.com/get-woke/woke/blob/main/CONTRIBUTING.md)
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features) see [docs/README.md](https://github.com/get-woke/woke/blob/main/docs/README.md)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix


**What is the current behavior?** (You can also link to an open issue here)
Running the installer script on arm64 fails with `get-woke/woke crit platform linux/arm64 is not supported.`


**What is the new behavior (if this is a feature change)?**
Installer script works for arm64


**Does this PR introduce a breaking change?** (What changes might users need to make due to this PR?)
No

**Other information**: Should fix #199 but I don't have an M1 to verify

Verification can be done via the command:

`curl -sSLf https://raw.githubusercontent.com/get-woke/woke/issue/199/install.sh | bash -s -- -b /usr/local/bin -d`
