### PR TITLE
Add support for 'checkstyle' output

### DIFF
--- a/docs/snippets/woke.md
+++ b/docs/snippets/woke.md
@@ -27,7 +27,7 @@ woke [globs ...] [flags]
       --exit-1-on-failure       Exit with exit code 1 on failures
   -h, --help                    help for woke
       --no-ignore               Ignored files in .gitignore, .ignore, .wokeignore, .git/info/exclude, and inline ignores are processed
-  -o, --output string           Output type [text,simple,github-actions,json,sonarqube] (default "text")
+  -o, --output string           Output type [text,simple,github-actions,json,sonarqube,checkstyle] (default "text")
       --stdin                   Read from stdin
 ```
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -63,7 +63,7 @@ This option may not be used at the same time as [File Globs](#file-globs)
 
 ## Outputs
 
-Options for output include text (default), simple, json, github-actions, or sonarqube format.
+Options for output include text (default), simple, json, github-actions, sonarqube or checkstyle format.
 The following fields are supported, depending on format:
 
 | Field        | Description                                       |
@@ -215,6 +215,24 @@ Format used to populate results into the popular [SonarQube](https://www.sonarqu
 
 !!! note
     `<sonarqubeseverity>` is mapped from severity, such that an error in `woke` is translated to a `MAJOR`, warning to a `MINOR`, and info to `INFO`
+
+### Checkstyle
+
+!!! example ""
+    `woke -o checkstyle`
+
+Format used to populate results into the [Checkstyle](https://checkstyle.org/) XML format.
+
+#### Structure
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<checkstyle version="5.0">
+  <file name="filepath">
+    <error column="startcol" line="lineno" message="description" severity="severity" source="woke"/>
+  </file>
+</checkstyle>
+```
 
 ## Exit Code
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -63,7 +63,7 @@ This option may not be used at the same time as [File Globs](#file-globs)
 
 ## Outputs
 
-Options for output include text (default), simple, json, github-actions, sonarqube or checkstyle format.
+Options for output include text (default), simple, json, github-actions, sonarqube, or checkstyle format.
 The following fields are supported, depending on format:
 
 | Field        | Description                                       |

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -229,7 +229,7 @@ Format used to populate results into the [Checkstyle](https://checkstyle.org/) X
 <?xml version="1.0" encoding="UTF-8"?>
 <checkstyle version="5.0">
   <file name="filepath">
-    <error column="startcol" line="lineno" message="description" severity="severity" source="woke"/>
+    <error column="startcol" line="lineno" message="description" severity="severity" source="woke"></error>
   </file>
 </checkstyle>
 ```

--- a/pkg/printer/checkstyle.go
+++ b/pkg/printer/checkstyle.go
@@ -1,0 +1,60 @@
+package printer
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/get-woke/woke/pkg/result"
+	"github.com/get-woke/woke/pkg/rule"
+)
+
+// Checkstyle is a Checkstyle printer meant for use by a Checkstyle annotation
+type Checkstyle struct {
+	writer io.Writer
+}
+
+// NewGitHubActions returns a new GitHubActions printer
+func NewCheckstyle(w io.Writer) *Checkstyle {
+	return &Checkstyle{writer: w}
+}
+
+func (p *Checkstyle) PrintSuccessExitMessage() bool {
+	return true
+}
+
+// Print prints in the format for Checkstyle
+// https://docs.github.com/en/actions/reference/workflow-commands-for-github-actions#setting-an-error-message
+func (p *Checkstyle) Print(fs *result.FileResults) error {
+	fmt.Fprintf(p.writer, "  <file name=\"%s\">\n", fs.Filename)
+	for _, r := range fs.Results {
+		fmt.Fprintln(p.writer, formatResultForCheckstyle(r))
+	}
+	fmt.Fprintln(p.writer, `  </file>`)
+	return nil
+}
+
+func (p *Checkstyle) Start() {
+	fmt.Fprintln(p.writer, `<?xml version="1.0" encoding="UTF-8"?>
+<checkstyle version="5.0">`)
+}
+
+func (p *Checkstyle) End() {
+	fmt.Fprintln(p.writer, `</checkstyle>`)
+}
+
+func formatResultForCheckstyle(r result.Result) string {
+	return fmt.Sprintf(`    <error column="%d" line="%d" message="%s" severity="%s" source="woke"/>`,
+		r.GetStartPosition().Column,
+		r.GetStartPosition().Line,
+		r.Reason(),
+		translateSeverityForCheckstyle(r.GetSeverity()),
+	)
+}
+
+func translateSeverityForCheckstyle(s rule.Severity) string {
+	if s == rule.SevError {
+		return "error"
+	}
+	// treat everything else as a warning
+	return "warning"
+}

--- a/pkg/printer/checkstyle.go
+++ b/pkg/printer/checkstyle.go
@@ -5,7 +5,6 @@ import (
 	"io"
 
 	"github.com/get-woke/woke/pkg/result"
-	"github.com/get-woke/woke/pkg/rule"
 )
 
 // Checkstyle is a Checkstyle printer meant for use by a Checkstyle annotation
@@ -47,14 +46,6 @@ func formatResultForCheckstyle(r result.Result) string {
 		r.GetStartPosition().Column,
 		r.GetStartPosition().Line,
 		r.Reason(),
-		translateSeverityForCheckstyle(r.GetSeverity()),
+		r.GetSeverity(),
 	)
-}
-
-func translateSeverityForCheckstyle(s rule.Severity) string {
-	if s == rule.SevError {
-		return "error"
-	}
-	// treat everything else as a warning
-	return "warning"
 }

--- a/pkg/printer/checkstyle.go
+++ b/pkg/printer/checkstyle.go
@@ -60,16 +60,24 @@ func (p *Checkstyle) Print(fs *result.FileResults) error {
 func (p *Checkstyle) Start() {
 	fmt.Fprint(p.writer, xml.Header)
 	p.encoder.Indent("", "  ")
-	p.encoder.EncodeToken(xml.StartElement{
+	if err := p.encoder.EncodeToken(xml.StartElement{
 		Name: xml.Name{Local: "checkstyle"},
 		Attr: []xml.Attr{
 			{Name: xml.Name{Local: "version"}, Value: "5.0"},
 		},
-	})
-	p.encoder.Flush()
+	}); err != nil {
+		panic(err)
+	}
+	if err := p.encoder.Flush(); err != nil {
+		panic(err)
+	}
 }
 
 func (p *Checkstyle) End() {
-	p.encoder.EncodeToken(xml.EndElement{Name: xml.Name{Local: "checkstyle"}})
-	p.encoder.Flush()
+	if err := p.encoder.EncodeToken(xml.EndElement{Name: xml.Name{Local: "checkstyle"}}); err != nil {
+		panic(err)
+	}
+	if err := p.encoder.Flush(); err != nil {
+		panic(err)
+	}
 }

--- a/pkg/printer/checkstyle.go
+++ b/pkg/printer/checkstyle.go
@@ -13,7 +13,7 @@ type Checkstyle struct {
 	writer io.Writer
 }
 
-// NewGitHubActions returns a new GitHubActions printer
+// NewCheckstyle returns a new Checkstyle printer
 func NewCheckstyle(w io.Writer) *Checkstyle {
 	return &Checkstyle{writer: w}
 }
@@ -22,8 +22,8 @@ func (p *Checkstyle) PrintSuccessExitMessage() bool {
 	return true
 }
 
-// Print prints in the format for Checkstyle
-// https://docs.github.com/en/actions/reference/workflow-commands-for-github-actions#setting-an-error-message
+// Print prints in the format for Checkstyle.
+// https://github.com/checkstyle/checkstyle
 func (p *Checkstyle) Print(fs *result.FileResults) error {
 	fmt.Fprintf(p.writer, "  <file name=\"%s\">\n", fs.Filename)
 	for _, r := range fs.Results {

--- a/pkg/printer/checkstyle_test.go
+++ b/pkg/printer/checkstyle_test.go
@@ -1,0 +1,55 @@
+package printer
+
+import (
+	"bytes"
+	"go/token"
+	"testing"
+
+	"github.com/get-woke/woke/pkg/result"
+	"github.com/get-woke/woke/pkg/rule"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFormatResultForCheckstyle(t *testing.T) {
+	testResult := result.LineResult{
+		Rule:    &rule.TestRule,
+		Finding: "whitelist",
+		StartPosition: &token.Position{
+			Filename: "my/file",
+			Offset:   0,
+			Line:     5,
+			Column:   3,
+		},
+		EndPosition: &token.Position{
+			Filename: "my/file",
+			Offset:   0,
+			Line:     5,
+			Column:   12,
+		},
+	}
+	got := formatResultForCheckstyle(&testResult)
+	assert.Equal(t,
+		"    <error column=\"3\" line=\"5\" message=\"`whitelist` may be insensitive, use `allowlist` instead\" severity=\"warning\" source=\"woke\"/>",
+		got)
+}
+
+func TestCheckstyle_Start(t *testing.T) {
+	buf := new(bytes.Buffer)
+	p := NewCheckstyle(buf)
+	p.Start()
+	got := buf.String()
+
+	expected := "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<checkstyle version=\"5.0\">\n"
+	assert.Equal(t, expected, got)
+}
+
+func TestCheckstyle_End(t *testing.T) {
+	buf := new(bytes.Buffer)
+	p := NewCheckstyle(buf)
+	p.End()
+	got := buf.String()
+
+	expected := "</checkstyle>\n"
+	assert.Equal(t, expected, got)
+}

--- a/pkg/printer/checkstyle_test.go
+++ b/pkg/printer/checkstyle_test.go
@@ -12,44 +12,37 @@ import (
 )
 
 func TestFormatResultForCheckstyle(t *testing.T) {
-	testResult := result.LineResult{
-		Rule:    &rule.TestRule,
-		Finding: "whitelist",
-		StartPosition: &token.Position{
-			Filename: "my/file",
-			Offset:   0,
-			Line:     5,
-			Column:   3,
-		},
-		EndPosition: &token.Position{
-			Filename: "my/file",
-			Offset:   0,
-			Line:     5,
-			Column:   12,
+	testResults := result.FileResults{
+		Filename: "my/file",
+		Results: []result.Result{
+			result.LineResult{
+				Rule:    &rule.TestRule,
+				Finding: "whitelist",
+				StartPosition: &token.Position{
+					Filename: "my/file",
+					Offset:   0,
+					Line:     5,
+					Column:   3,
+				},
+				EndPosition: &token.Position{
+					Filename: "my/file",
+					Offset:   0,
+					Line:     5,
+					Column:   12,
+				},
+			},
 		},
 	}
-	got := formatResultForCheckstyle(&testResult)
-	assert.Equal(t,
-		"    <error column=\"3\" line=\"5\" message=\"`whitelist` may be insensitive, use `allowlist` instead\" severity=\"warning\" source=\"woke\"/>",
-		got)
-}
-
-func TestCheckstyle_Start(t *testing.T) {
 	buf := new(bytes.Buffer)
 	p := NewCheckstyle(buf)
 	p.Start()
-	got := buf.String()
-
-	expected := "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<checkstyle version=\"5.0\">\n"
-	assert.Equal(t, expected, got)
-}
-
-func TestCheckstyle_End(t *testing.T) {
-	buf := new(bytes.Buffer)
-	p := NewCheckstyle(buf)
+	p.Print(&testResults)
 	p.End()
-	got := buf.String()
-
-	expected := "</checkstyle>\n"
-	assert.Equal(t, expected, got)
+	expected := `<?xml version="1.0" encoding="UTF-8"?>
+<checkstyle version="5.0">
+  <file name="my/file">
+    <error column="3" line="5" message="` + "`" + `whitelist` + "`" + ` may be insensitive, use ` + "`" + `allowlist` + "`" + ` instead" severity="warning" source="woke"></error>
+  </file>
+</checkstyle>`
+	assert.Equal(t, expected, buf.String())
 }

--- a/pkg/printer/checkstyle_test.go
+++ b/pkg/printer/checkstyle_test.go
@@ -46,3 +46,25 @@ func TestFormatResultForCheckstyle(t *testing.T) {
 </checkstyle>`
 	assert.Equal(t, expected, buf.String())
 }
+
+func TestCheckstyle_Start(t *testing.T) {
+	buf := new(bytes.Buffer)
+	p := NewCheckstyle(buf)
+	p.Start()
+	got := buf.String()
+
+	expected := `<?xml version="1.0" encoding="UTF-8"?>
+<checkstyle version="5.0">`
+	assert.Equal(t, expected, got)
+}
+
+func TestCheckstyle_End(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Errorf("Expected panic: end tag </checkstyle> without start tag")
+		}
+	}()
+	buf := new(bytes.Buffer)
+	p := NewCheckstyle(buf)
+	p.End()
+}

--- a/pkg/printer/checkstyle_test.go
+++ b/pkg/printer/checkstyle_test.go
@@ -59,12 +59,7 @@ func TestCheckstyle_Start(t *testing.T) {
 }
 
 func TestCheckstyle_End(t *testing.T) {
-	defer func() {
-		if r := recover(); r == nil {
-			t.Errorf("Expected panic: end tag </checkstyle> without start tag")
-		}
-	}()
 	buf := new(bytes.Buffer)
 	p := NewCheckstyle(buf)
-	p.End()
+	assert.PanicsWithError(t, "xml: end tag </checkstyle> without start tag", func() { p.End() })
 }

--- a/pkg/printer/printer.go
+++ b/pkg/printer/printer.go
@@ -34,6 +34,10 @@ const (
 	// OutFormatSonarQube is an output format supported by SonarQube
 	// https://docs.sonarqube.org/latest/analysis/generic-issue/
 	OutFormatSonarQube = "sonarqube"
+
+	// OutFormatCheckstyle outputs in checkstyle format.
+	// https://github.com/checkstyle/checkstyle
+	OutFormatCheckstyle = "checkstyle"
 )
 
 // OutFormats are all the available output formats. The first one should be the default
@@ -42,6 +46,7 @@ var OutFormats = []string{
 	OutFormatSimple,
 	OutFormatGitHubActions,
 	OutFormatJSON,
+	OutFormatCheckstyle,
 	OutFormatSonarQube,
 }
 
@@ -62,6 +67,8 @@ func NewPrinter(f string, w io.Writer) (Printer, error) {
 		p = NewJSON(w)
 	case OutFormatSonarQube:
 		p = NewSonarQube(w)
+	case OutFormatCheckstyle:
+		p = NewCheckstyle(w)
 	default:
 		return p, fmt.Errorf("%s is not a valid printer type", f)
 	}

--- a/pkg/printer/printer.go
+++ b/pkg/printer/printer.go
@@ -46,8 +46,8 @@ var OutFormats = []string{
 	OutFormatSimple,
 	OutFormatGitHubActions,
 	OutFormatJSON,
-	OutFormatCheckstyle,
 	OutFormatSonarQube,
+	OutFormatCheckstyle,
 }
 
 // OutFormatsString is all OutFormats, as a comma-separated string

--- a/pkg/printer/printer_test.go
+++ b/pkg/printer/printer_test.go
@@ -17,6 +17,7 @@ func TestCreatePrinter(t *testing.T) {
 		{OutFormatGitHubActions, &GitHubActions{}},
 		{OutFormatJSON, &JSON{}},
 		{OutFormatSonarQube, &SonarQube{}},
+		{OutFormatCheckstyle, &Checkstyle{}},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The commit message follows our [guidelines](https://github.com/get-woke/woke/blob/main/CONTRIBUTING.md)
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features) see [docs/README.md](https://github.com/get-woke/woke/blob/main/docs/README.md)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Add support for the `checkstyle` output format. Checkstyle is a static code analysis tool used in software development.

**What is the current behavior?** (You can also link to an open issue here)

Currently, `woke` supports the following output formats: `text`, `simple`, `github-actions`, `json` and `sonarqube`.

**What is the new behavior (if this is a feature change)?**

Adding new output format (checkstyle).

**Does this PR introduce a breaking change?** (What changes might users need to make due to this PR?)

No

**Other information**:

Checkstyle is a static code analysis tool used in software development. While **checkstyle** was originally designed for Java static analysis, multiple CICD tools support the `checkstyle` XML format. The checkstyle format can be used to report generic static analysis issues, not just Java. A list of supported tools is available at https://checkstyle.org/index.html#Related_Tools_Active_Tools

For example:
1. [golangci-lint](https://golangci-lint.run/usage/configuration/#output-configuration) can produce output of **golang** static analysis in `checkstyle` format.
1. The [Jenkins warning NG plug-in](https://github.com/jenkinsci/warnings-ng-plugin/blob/master/SUPPORTED-FORMATS.md) can show the results of static analysis using `checkstyle` format.

Though the `checkstyle` format is very simple, there is no formal XSD. See https://github.com/checkstyle/checkstyle/issues/5166