### PR TITLE
ci: Add PR test for running goreleaser snapshot

### DIFF
--- a/.github/workflows/goreleaser-snapshot.yml
+++ b/.github/workflows/goreleaser-snapshot.yml
@@ -1,0 +1,30 @@
+# This is used to test changes to goreleaser-related files.
+# It should never publish. Publishing should be handled in the `tag.yml` action
+name: Goreleaser snapshot
+
+on:
+  pull_request:
+    paths:
+      - .goreleaser.yml
+      - build/Dockerfile
+      - .github/workflows/goreleaser-snapshot.yml
+
+jobs:
+  goreleaser:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Setup Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.17
+
+      - name: Create snapshot
+        uses: goreleaser/goreleaser-action@v2
+        with:
+          version: latest
+          args: release --snapshot --rm-dist


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The commit message follows our [guidelines](https://github.com/get-woke/woke/blob/main/CONTRIBUTING.md)
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features) see [docs/README.md](https://github.com/get-woke/woke/blob/main/docs/README.md)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
CI


**What is the current behavior?** (You can also link to an open issue here)
There is no CI check to validate changes to goreleaser. 


**What is the new behavior (if this is a feature change)?**
We now run `goreleaser release --snapshot --rm-dist` on PRs when related files are changed. 


**Does this PR introduce a breaking change?** (What changes might users need to make due to this PR?)
No

**Other information**:
This is related to possible breaking changes to releases in https://github.com/get-woke/woke/pull/216 that would not be shown during CI
