### PR TITLE
ci: Update permissions on first-interaction action

### DIFF
--- a/.github/workflows/greeting.yml
+++ b/.github/workflows/greeting.yml
@@ -10,6 +10,11 @@ jobs:
   greet-user:
     name: Greeting Action
     runs-on: ubuntu-latest
+    # Hopefully this will help with the "Resource not accessible by integration" error
+    # https://github.com/actions/first-interaction/issues/10#issuecomment-1114048624
+    permissions:
+      issues: write
+      pull-requests: write
 
     # Runs the greeting action (Options can be found here https://github.com/actions/first-interaction)
     steps:


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The commit message follows our [guidelines](https://github.com/get-woke/woke/blob/main/CONTRIBUTING.md)
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features) see [docs/README.md](https://github.com/get-woke/woke/blob/main/docs/README.md)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
CI


**What is the current behavior?** (You can also link to an open issue here)
I noticed on some PRs, the greeting action fails with an error `Resource not accessible by integration`. A github search led me to this [comment](https://github.com/actions/first-interaction/issues/10#issuecomment-1114048624), which suggests configuring permissions for the action. Some say it works, some say it doesn't. Let's give it a try.


**What is the new behavior (if this is a feature change)?**
Add permissions to the greeting action


**Does this PR introduce a breaking change?** (What changes might users need to make due to this PR?)
No

**Other information**:
