### PR TITLE
docs: fix URL to releases page

### DIFF
--- a/docs/ignore.md
+++ b/docs/ignore.md
@@ -20,7 +20,7 @@ ignore_files:
 You may also specify a `.wokeignore` file at the root of the directory to add additional ignore files.
 This also follows the [gitignore](https://git-scm.com/docs/gitignore) convention.
 
-See [.wokeignore.example]({{config.repo_url}}blob/main/.wokeignore.example) for a collection of common files and directories that may contain generated [SHA](https://en.wikipedia.org/wiki/Secure_Hash_Algorithms) and [GUID](https://en.wikipedia.org/wiki/Universally_unique_identifier)s. Dependency directories are also shown in the example as the linter will parse dependency source code and possibly find errors.
+See [.wokeignore.example]({{config.repo_url}}/blob/main/.wokeignore.example) for a collection of common files and directories that may contain generated [SHA](https://en.wikipedia.org/wiki/Secure_Hash_Algorithms) and [GUID](https://en.wikipedia.org/wiki/Universally_unique_identifier)s. Dependency directories are also shown in the example as the linter will parse dependency source code and possibly find errors.
 
 ## In-line and next-line ignoring
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,13 +6,13 @@
 </p>
 
 <div align="center">
-  <a href="{{config.repo_url}}releases">
+  <a href="{{config.repo_url}}/releases">
     <img alt="GitHub latest release" src="https://img.shields.io/github/v/release/get-woke/woke?logo=github&sort=semver">
   </a>
-  <a href="{{config.repo_url}}releases">
+  <a href="{{config.repo_url}}/releases">
     <img alt="GitHub Downloads" src="https://img.shields.io/github/downloads/get-woke/woke/total">
   </a>
-  <a href="{{config.repo_url}}blob/main/LICENSE">
+  <a href="{{config.repo_url}}/blob/main/LICENSE">
     <img alt="License" src="https://img.shields.io/badge/license-MIT-blue.svg">
   </a>
   <a href="https://codecov.io/gh/get-woke/woke/branch/main">

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -6,7 +6,7 @@
 
 ## Releases
 
-Download the latest binary from [Releases]({{config.repo_url}}releases/latest)
+Download the latest binary from [Releases]({{config.repo_url}}/releases/latest)
 
 ## macOS
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -2,7 +2,7 @@
 
 !!! tip
     There are multiple ways to install `woke`. If you're interested in any installation methods
-    that are not listed here, feel free to open an [issue]({{config.repo_url}}issues).
+    that are not listed here, feel free to open an [issue]({{config.repo_url}}/issues).
 
 ## Releases
 

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -22,7 +22,7 @@ rules:
     #   categories: nil
 ```
 
-A set of default rules is provided in [`pkg/rule/default.yaml`]({{config.repo_url}}blob/main/pkg/rule/default.yaml).
+A set of default rules is provided in [`pkg/rule/default.yaml`]({{config.repo_url}}/blob/main/pkg/rule/default.yaml).
 
 !!! tip
     If you copy these rules into your config file, be sure to put them under the `rules:` key.

--- a/docs/snippets/about.md
+++ b/docs/snippets/about.md
@@ -2,15 +2,15 @@
 
 - **Caitlin Elfring** - [caitlinelfring](https://github.com/caitlinelfring)
 
-See also the list of [contributors]({{config.repo_url}}contributors) who participated in this project.
+See also the list of [contributors]({{config.repo_url}}/contributors) who participated in this project.
 
 ## Contributing
 
-Please read [CONTRIBUTING.md]({{config.repo_url}}blob/main/CONTRIBUTING.md) for details on our code of conduct, and the process for submitting pull requests to us.
+Please read [CONTRIBUTING.md]({{config.repo_url}}/blob/main/CONTRIBUTING.md) for details on our code of conduct, and the process for submitting pull requests to us.
 
 ## License
 
 This application is licensed under the MIT License, you may obtain a copy of it
-[here]({{config.repo_url}}blob/main/LICENSE).
+[here]({{config.repo_url}}/blob/main/LICENSE).
 
 [![FOSSA Status](https://app.fossa.com/api/projects/git%2Bgithub.com%2Fget-woke%2Fwoke.svg?type=large)](https://app.fossa.com/projects/git%2Bgithub.com%2Fget-woke%2Fwoke?ref=badge_large)

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -11,7 +11,7 @@ Configure your custom rules config in `.woke.yaml` or `.woke.yml`. `woke` uses t
 
 This file will be picked up automatically up your customizations without needing to supply it with the `-c` flag.
 
-See [example.yaml]({{config.repo_url}}blob/main/example.yaml) for an example of adding custom rules.
+See [example.yaml]({{config.repo_url}}/blob/main/example.yaml) for an example of adding custom rules.
 You can also supply your own rules with `-c path/to/rules.yaml` if you want to handle different rulesets.
 
 ### Remote config file


### PR DESCRIPTION
Adds the missing slash in the URL to the releases page.

**Please check if the PR fulfills these requirements**

- [x] The commit message follows our [guidelines](https://github.com/get-woke/woke/blob/main/CONTRIBUTING.md)
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features) see [docs/README.md](https://github.com/get-woke/woke/blob/main/docs/README.md)

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Fixes a single URL.

**What is the current behavior?** (You can also link to an open issue here)

The link is broken, the documentation page https://docs.getwoke.tech/installation/#releases redirects to the incorrect URL https://github.com/get-woke/wokereleases/latest

**What is the new behavior (if this is a feature change)?**

The link will actually work

**Does this PR introduce a breaking change?** (What changes might users need to make due to this PR?)

No

**Other information**:

None