### PR TITLE
ci: Roll back golangci-lint version to v1.47.3

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -95,3 +95,6 @@ jobs:
         with:
           go-version: ${{ matrix.go-version }}
       - uses: golangci/golangci-lint-action@v3.2.0
+        with:
+          # https://github.com/golangci/golangci-lint-action/issues/535
+          version: v1.47.3


### PR DESCRIPTION

**Please check if the PR fulfills these requirements**

- [x] The commit message follows our [guidelines](https://github.com/get-woke/woke/blob/main/CONTRIBUTING.md)
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features) see [docs/README.md](https://github.com/get-woke/woke/blob/main/docs/README.md)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Fix for failing CI 


**What is the current behavior?** (You can also link to an open issue here)
https://github.com/golangci/golangci-lint-action/issues/535


**What is the new behavior (if this is a feature change)?**
Hardcode a previous version, which should be stable


**Does this PR introduce a breaking change?** (What changes might users need to make due to this PR?)
No

**Other information**:
