### PR TITLE
remove use of deprecated ioutil package

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -128,7 +127,7 @@ func (c *Config) RemoveRule(i int) {
 }
 
 func loadConfig(filename string) (c Config, err error) {
-	yamlFile, err := ioutil.ReadFile(filename)
+	yamlFile, err := os.ReadFile(filename)
 	log.Debug().Str("filename", filename).Msg("Adding custom ruleset from")
 	if err != nil {
 		return c, err

--- a/pkg/parser/findings_test.go
+++ b/pkg/parser/findings_test.go
@@ -2,7 +2,6 @@ package parser
 
 import (
 	"go/token"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -101,7 +100,7 @@ func newFile(t *testing.T, text string) (*os.File, error) {
 // newFile creates a new file with the prefix defined for testing.
 // The file, and the directory that the file was created in will be removed at the completion of the test
 func newFileWithPrefix(t *testing.T, prefix, text string) (*os.File, error) {
-	tmpFile, err := ioutil.TempFile(os.TempDir(), prefix)
+	tmpFile, err := os.CreateTemp(os.TempDir(), prefix)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -2,7 +2,6 @@ package parser
 
 import (
 	"go/token"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -284,7 +283,7 @@ func TestParser_ParsePaths(t *testing.T) {
 }
 
 func writeToStdin(t *testing.T, text string, f func()) error {
-	tmpfile, err := ioutil.TempFile(os.TempDir(), "")
+	tmpfile, err := os.CreateTemp(os.TempDir(), "")
 	if err != nil {
 		return err
 	}
@@ -310,7 +309,7 @@ func writeToStdin(t *testing.T, text string, f func()) error {
 
 func BenchmarkParsePaths(b *testing.B) {
 	zerolog.SetGlobalLevel(zerolog.NoLevel)
-	tmpFile, err := ioutil.TempFile(b.TempDir(), "")
+	tmpFile, err := os.CreateTemp(b.TempDir(), "")
 	assert.NoError(b, err)
 
 	for i := 0; i < 100; i++ {

--- a/pkg/walker/walker_test.go
+++ b/pkg/walker/walker_test.go
@@ -1,7 +1,6 @@
 package walker
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -11,7 +10,7 @@ import (
 )
 
 func TestWalker_Walk(t *testing.T) {
-	dir, err := ioutil.TempDir(os.TempDir(), "")
+	dir, err := os.MkdirTemp(os.TempDir(), "")
 	assert.NoError(t, err)
 	defer os.RemoveAll(dir)
 	assert.DirExists(t, dir)


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The commit message follows our [guidelines](https://github.com/get-woke/woke/blob/main/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) see [docs/README.md](https://github.com/get-woke/woke/blob/main/docs/README.md)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

This is removing use of `ioutil` package which is deprecated.

**What is the current behavior?** (You can also link to an open issue here)

No change.

**What is the new behavior (if this is a feature change)?**

No change.

**Does this PR introduce a breaking change?** (What changes might users need to make due to this PR?)

No

**Other information**:
