### PR TITLE
refactor UT to make it easier to test glob expansion

### DIFF
--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"io"
 	"os"
-	"path/filepath"
 	"regexp"
 	"strings"
 	"testing"
@@ -88,7 +87,7 @@ func TestParseArgs(t *testing.T) {
 		{
 			stdin:        false,
 			args:         []string{"../.."},
-			expectedArgs: []string{filepath.Join("..", "..")},
+			expectedArgs: []string{"../.."},
 		},
 		{
 			stdin:        true,


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The commit message follows our [guidelines](https://github.com/get-woke/woke/blob/main/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) see [docs/README.md](https://github.com/get-woke/woke/blob/main/docs/README.md)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

This is a small UT refactor to make it easier to add future sub-tests in `TestParseArgs`. Each test case is now executed as a sub-test. This is used to add UTs in https://github.com/get-woke/woke/pull/211. The purpose of this PR is to show the refactor without changing the set of UTs.

**What is the current behavior?** (You can also link to an open issue here)

Currently, there are no sub-tests for file glob patterns.

**What is the new behavior (if this is a feature change)?**

No change.

**Does this PR introduce a breaking change?** (What changes might users need to make due to this PR?)


**Other information**:
