### PR TITLE
upgrade to golangci-lint 1.50.1

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -97,4 +97,4 @@ jobs:
       - uses: golangci/golangci-lint-action@v3.2.0
         with:
           # https://github.com/golangci/golangci-lint-action/issues/535
-          version: v1.47.3
+          version: v1.50.1

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -20,9 +20,12 @@ import (
 // run profiling with
 // go test -v -cpuprofile cpu.prof -memprofile mem.prof -bench=. ./cmd
 // memory:
-//    go tool pprof mem.prof
+//
+//	go tool pprof mem.prof
+//
 // cpu:
-//    go tool pprof cpu.prof
+//
+//	go tool pprof cpu.prof
 func BenchmarkRootRunE(b *testing.B) {
 	zerolog.SetGlobalLevel(zerolog.NoLevel)
 	output.Stdout = io.Discard


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The commit message follows our [guidelines](https://github.com/get-woke/woke/blob/main/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) see [docs/README.md](https://github.com/get-woke/woke/blob/main/docs/README.md)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

1. Upgrade golangci-lint version to 1.50.1. The new version of `golangci-lint` warns about deprecated usage of `ioutil` package.
2. Reformat code according to go 1.19 formatting rules. This is backwards-compatible with previous versions of golang.

**What is the current behavior?** (You can also link to an open issue here)



**What is the new behavior (if this is a feature change)?**

no change.

**Does this PR introduce a breaking change?** (What changes might users need to make due to this PR?)


**Other information**:
