### PR TITLE
Add flag to disable nested ignores

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 # First: Install pre-commit https://pre-commit.com/#install
 # Then, run `pre-commit install`
 repos:
-  - repo: git://github.com/caitlinelfring/pre-commit-golang
+  - repo: https://github.com/caitlinelfring/pre-commit-golang
     rev: v0.4.0
     hooks:
       - id: go-fmt

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -45,13 +45,14 @@ import (
 
 var (
 	// flags
-	exitOneOnFailure    bool
-	cfgFile             string
-	debug               bool
-	stdin               bool
-	outputName          string
-	noIgnore            bool
-	disableDefaultRules bool
+	exitOneOnFailure       bool
+	cfgFile                string
+	debug                  bool
+	stdin                  bool
+	outputName             string
+	noIgnore               bool
+	disableDefaultRules    bool
+	disableIgnoreTraversal bool
 
 	// Version is populated by goreleaser during build
 	// Version...
@@ -109,7 +110,7 @@ func rootRunE(cmd *cobra.Command, args []string) error {
 		if err != nil {
 			return err
 		}
-		ignorer, err = ignore.NewIgnore(fs, cfg.IgnoreFiles)
+		ignorer, err = ignore.NewIgnore(fs, cfg.IgnoreFiles, disableIgnoreTraversal)
 		if err != nil {
 			return err
 		}
@@ -155,6 +156,7 @@ func init() {
 	rootCmd.PersistentFlags().BoolVar(&noIgnore, "no-ignore", false, "Ignored files in .gitignore, .ignore, .wokeignore, .git/info/exclude, and inline ignores are processed")
 	rootCmd.PersistentFlags().StringVarP(&outputName, "output", "o", printer.OutFormatText, fmt.Sprintf("Output type [%s]", printer.OutFormatsString))
 	rootCmd.PersistentFlags().BoolVar(&disableDefaultRules, "disable-default-rules", false, "Disable the default ruleset")
+	rootCmd.PersistentFlags().BoolVar(&disableIgnoreTraversal, "disable-ignore-traversal", false, "Disable nested woke ignore traversal")
 }
 
 // GetRootCmd returns the rootCmd, which should only be used by the docs generator in cmd/docs/main.go

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -45,14 +45,14 @@ import (
 
 var (
 	// flags
-	exitOneOnFailure       bool
-	cfgFile                string
-	debug                  bool
-	stdin                  bool
-	outputName             string
-	noIgnore               bool
-	disableDefaultRules    bool
-	disableIgnoreTraversal bool
+	exitOneOnFailure     bool
+	cfgFile              string
+	debug                bool
+	stdin                bool
+	outputName           string
+	noIgnore             bool
+	disableDefaultRules  bool
+	disableNestedIgnores bool
 
 	// Version is populated by goreleaser during build
 	// Version...
@@ -110,7 +110,7 @@ func rootRunE(cmd *cobra.Command, args []string) error {
 		if err != nil {
 			return err
 		}
-		ignorer, err = ignore.NewIgnore(fs, cfg.IgnoreFiles, disableIgnoreTraversal)
+		ignorer, err = ignore.NewIgnore(fs, cfg.IgnoreFiles, disableNestedIgnores)
 		if err != nil {
 			return err
 		}
@@ -156,7 +156,7 @@ func init() {
 	rootCmd.PersistentFlags().BoolVar(&noIgnore, "no-ignore", false, "Ignored files in .gitignore, .ignore, .wokeignore, .git/info/exclude, and inline ignores are processed")
 	rootCmd.PersistentFlags().StringVarP(&outputName, "output", "o", printer.OutFormatText, fmt.Sprintf("Output type [%s]", printer.OutFormatsString))
 	rootCmd.PersistentFlags().BoolVar(&disableDefaultRules, "disable-default-rules", false, "Disable the default ruleset")
-	rootCmd.PersistentFlags().BoolVar(&disableIgnoreTraversal, "disable-ignore-traversal", false, "Disable nested woke ignore traversal")
+	rootCmd.PersistentFlags().BoolVar(&disableNestedIgnores, "disable-nested-ignores", false, "Disable nested woke ignore traversal")
 }
 
 // GetRootCmd returns the rootCmd, which should only be used by the docs generator in cmd/docs/main.go

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -20,9 +20,12 @@ import (
 // run profiling with
 // go test -v -cpuprofile cpu.prof -memprofile mem.prof -bench=. ./cmd
 // memory:
-//    go tool pprof mem.prof
+//
+//	go tool pprof mem.prof
+//
 // cpu:
-//    go tool pprof cpu.prof
+//
+//	go tool pprof cpu.prof
 func BenchmarkRootRunE(b *testing.B) {
 	zerolog.SetGlobalLevel(zerolog.NoLevel)
 	output.Stdout = io.Discard

--- a/docs/ignore.md
+++ b/docs/ignore.md
@@ -79,6 +79,8 @@ func main() {
 
 `woke` will apply ignore rules from nested ignore files to any child files/folders, similar to a nested `.gitignore` file. Nested ignore files work for any ignore file type listed above.
 
+>Note: To disable nested ignore file functionality, run `woke` with the `--disable-nested-ignores` flag.
+
 ```txt
 project
 │   README.md

--- a/pkg/ignore/ignore.go
+++ b/pkg/ignore/ignore.go
@@ -1,6 +1,8 @@
 package ignore
 
 import (
+	"errors"
+	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -65,7 +67,7 @@ func GetRootGitDir(workingDir string) (filesystem billy.Filesystem, err error) {
 
 // NewIgnore produces an Ignore object, with compiled lines from defaultIgnoreFiles
 // which you can match files against
-func NewIgnore(filesystem billy.Filesystem, lines []string) (ignore *Ignore, err error) {
+func NewIgnore(filesystem billy.Filesystem, lines []string, disableIgnoreTraversal bool) (ignore *Ignore, err error) {
 	start := time.Now()
 	defer func() {
 		log.Debug().
@@ -79,8 +81,16 @@ func NewIgnore(filesystem billy.Filesystem, lines []string) (ignore *Ignore, err
 	}
 
 	var ps []gitignore.Pattern
-	if ps, err = gitignore.ReadPatterns(filesystem, nil, defaultIgnoreFiles); err != nil {
-		return
+
+	// if opted-out of nested wokeignore traversal, only use top-level ignore files
+	if disableIgnoreTraversal {
+		for _, filename := range defaultIgnoreFiles {
+			lines = append(lines, readIgnoreFile(filename)...)
+		}
+	} else {
+		if ps, err = gitignore.ReadPatterns(filesystem, nil, defaultIgnoreFiles); err != nil {
+			return
+		}
 	}
 
 	// get domain for git ignore rules supplied from the lines argument
@@ -90,11 +100,25 @@ func NewIgnore(filesystem billy.Filesystem, lines []string) (ignore *Ignore, err
 		ps = append(ps, pattern)
 	}
 
-	ignore = &Ignore{
+	return &Ignore{
 		matcher: gitignore.NewMatcher(ps),
+	}, nil
+}
+
+func readIgnoreFile(file string) []string {
+	buffer, err := ioutil.ReadFile(file)
+	if err != nil {
+		_event := log.Warn()
+		if errors.Is(err, os.ErrNotExist) {
+			_event = log.Debug()
+		}
+		_event.Err(err).Str("file", file).Msg("skipping ignorefile")
+		return []string{}
 	}
 
-	return
+	log.Debug().Str("file", file).Msg("adding ignorefile")
+
+	return strings.Split(strings.TrimSpace(string(buffer)), "\n")
 }
 
 // Match returns true if the provided file matches any of the defined ignores

--- a/pkg/ignore/ignore.go
+++ b/pkg/ignore/ignore.go
@@ -68,7 +68,7 @@ func GetRootGitDir(workingDir string) (filesystem billy.Filesystem, err error) {
 
 // NewIgnore produces an Ignore object, with compiled lines from defaultIgnoreFiles
 // which you can match files against
-func NewIgnore(filesystem billy.Filesystem, lines []string, disableIgnoreTraversal bool) (ignore *Ignore, err error) {
+func NewIgnore(filesystem billy.Filesystem, lines []string, disableNestedIgnores bool) (ignore *Ignore, err error) {
 	start := time.Now()
 	defer func() {
 		log.Debug().
@@ -84,7 +84,7 @@ func NewIgnore(filesystem billy.Filesystem, lines []string, disableIgnoreTravers
 	var ps []gitignore.Pattern
 
 	// if opted-out of nested wokeignore traversal, only use top-level ignore files
-	if disableIgnoreTraversal {
+	if disableNestedIgnores {
 		for _, filename := range defaultIgnoreFiles {
 			lines = append(lines, readIgnoreFile(filesystem, filename)...)
 		}

--- a/pkg/ignore/ignore_test.go
+++ b/pkg/ignore/ignore_test.go
@@ -103,7 +103,7 @@ func BenchmarkIgnore(b *testing.B) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		ignorer, err := NewIgnore(fs, []string{})
+		ignorer, err := NewIgnore(fs, []string{}, false)
 		assert.NoError(b, err)
 		ignorer.Match(filepath.Join("not", "foo"), false)
 	}
@@ -136,7 +136,7 @@ func (suite *IgnoreTestSuite) TestGetRootGitDirNotExist() {
 	suite.Equal(fs.Root(), rootFs.Root())
 }
 func (suite *IgnoreTestSuite) TestIgnore_Match() {
-	i, err := NewIgnore(suite.GFS, []string{"my/files/*"})
+	i, err := NewIgnore(suite.GFS, []string{"my/files/*"}, false)
 	suite.NoError(err)
 	suite.NotNil(i)
 
@@ -148,7 +148,7 @@ func (suite *IgnoreTestSuite) TestIgnore_Match() {
 // Test all default ignore files, except for .git/info/exclude, since
 // that uses a .git directory that we cannot check in.
 func (suite *IgnoreTestSuite) TestIgnoreDefaultIgoreFiles_Match() {
-	i, err := NewIgnore(suite.GFS, []string{"*.FROMARGUMENT"})
+	i, err := NewIgnore(suite.GFS, []string{"*.FROMARGUMENT"}, false)
 	suite.NoError(err)
 	suite.NotNil(i)
 

--- a/pkg/ignore/ignore_test.go
+++ b/pkg/ignore/ignore_test.go
@@ -112,14 +112,14 @@ func BenchmarkIgnore(b *testing.B) {
 	}
 
 	b.ResetTimer()
-	b.Run("ignore-traversal-enabled", func(b *testing.B) {
+	b.Run("nested-ignores-enabled", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
 			ignorer, err := NewIgnore(fs, []string{}, false)
 			assert.NoError(b, err)
 			ignorer.Match(filepath.Join("not", "foo"), false)
 		}
 	})
-	b.Run("ignore-traversal-disabled", func(b *testing.B) {
+	b.Run("nested-ignores-disabled", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
 			ignorer, err := NewIgnore(fs, []string{}, true)
 			assert.NoError(b, err)
@@ -185,7 +185,7 @@ func (suite *IgnoreTestSuite) TestIgnoreDefaultIgnoreFiles_Match() {
 	// Test top-level ignore files all match
 	suite.testCommonIgnoreDefaultIgnoreFilesMatch(i)
 
-	// Test match from the nested ./nestedIgnoreFolder/.wokeignore when ignore traversal is enabled
+	// Test match from the nested ./nestedIgnoreFolder/.wokeignore when nested ignores is enabled
 	suite.True(i.Match(filepath.Join("nestedIgnoreFolder", "testdata", "test.NESTEDIGNORE"), false))
 }
 
@@ -197,7 +197,7 @@ func (suite *IgnoreTestSuite) TestIgnoreDefaultIgnoreFilesNoTraversal_Match() {
 	// Test top-level ignore files all match
 	suite.testCommonIgnoreDefaultIgnoreFilesMatch(i)
 
-	// Test no match from the nested ./nestedIgnoreFolder/.wokeignore when ignore traversal is disabled
+	// Test no match from the nested ./nestedIgnoreFolder/.wokeignore when nested ignores is disabled
 	suite.False(i.Match(filepath.Join("nestedIgnoreFolder", "testdata", "test.NESTEDIGNORE"), false))
 }
 

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -43,7 +43,7 @@ func testParser() (parser *Parser, err error) {
 		return
 	}
 	fs := osfs.New(cwd)
-	ignorer, err := ignore.NewIgnore(fs, []string{})
+	ignorer, err := ignore.NewIgnore(fs, []string{}, false)
 	if err != nil {
 		return
 	}
@@ -149,7 +149,7 @@ func parsePathTests(t *testing.T) {
 		cwd, err := os.Getwd()
 		assert.NoError(t, err)
 		fs := osfs.New(cwd)
-		ignorer, err := ignore.NewIgnore(fs, []string{filepath.ToSlash(f.Name())})
+		ignorer, err := ignore.NewIgnore(fs, []string{filepath.ToSlash(f.Name())}, false)
 		assert.NoError(t, err)
 		p.Ignorer = ignorer
 		pr := new(testPrinter)
@@ -193,7 +193,7 @@ func parsePathTests(t *testing.T) {
 		cwd, err := os.Getwd()
 		assert.NoError(t, err)
 		fs := osfs.New(cwd)
-		ignorer, err := ignore.NewIgnore(fs, []string{"*_test.go"})
+		ignorer, err := ignore.NewIgnore(fs, []string{"*_test.go"}, false)
 		assert.NoError(t, err)
 		p.Ignorer = ignorer
 		pr := new(testPrinter)


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The commit message follows our [guidelines](https://github.com/get-woke/woke/blob/main/CONTRIBUTING.md)
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features) see [docs/README.md](https://github.com/get-woke/woke/blob/main/docs/README.md)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Feature


**What is the current behavior?** 
Nested ignores are currently enabled by default, which has the potential to cause performance issues in very large repositories (even when they have no nested ignores). See issue #239 for more on this.


**What is the new behavior (if this is a feature change)?**
As this is related to an already released feature, the safest bet is to add the following flag to opt-out: `--disable-nested-ignores`. This should match the original behavior of only checking for top-level ignore-files (i.e. nested ignore-files should no longer be considered when using this flag). 


**Does this PR introduce a breaking change?** (What changes might users need to make due to this PR?)
No

**Other information**:
Another PR should follow this one, attempting to address the performance issues with nested ignores turned on. 

Let me know your thoughts on this!