### PR TITLE
Replace broken link with Wayback Machine archive.

### DIFF
--- a/pkg/rule/default.yaml
+++ b/pkg/rule/default.yaml
@@ -1,5 +1,5 @@
 
-# Most of these are based on https://twitter.com/TwitterEng/status/1278733303508418560
+# Most of these are based on https://web.archive.org/web/20200704015026/https://twitter.com/TwitterEng/status/1278733303508418560
 - name: whitelist
   terms:
     - whitelist


### PR DESCRIPTION
The Twitter link broke at some point. This replaces it with a snapshot from Internet Archive's Wayback Machine.